### PR TITLE
security: add permissions block to workflows

### DIFF
--- a/.github/workflows/apm_serverless.yml
+++ b/.github/workflows/apm_serverless.yml
@@ -1,5 +1,8 @@
 name: APM on Serverless
 on: workflow_dispatch
+permissions:
+  contents: read
+
 jobs:
   install:
     timeout-minutes: 60

--- a/.github/workflows/infrastructure_serverless.yml
+++ b/.github/workflows/infrastructure_serverless.yml
@@ -1,5 +1,8 @@
 name: Infrastructure Monitoring on Serverless
 on: workflow_dispatch
+permissions:
+  contents: read
+
 jobs:
   install:
     timeout-minutes: 60

--- a/.github/workflows/scale_test.yml
+++ b/.github/workflows/scale_test.yml
@@ -1,5 +1,8 @@
 name: Test at a scale (100 Kibana sessions)
 on: workflow_dispatch
+permissions:
+  contents: read
+
 jobs:
   install:
     timeout-minutes: 60

--- a/.github/workflows/soft_scale_test.yml
+++ b/.github/workflows/soft_scale_test.yml
@@ -1,5 +1,8 @@
 name: Test at a scale (10 Kibana sessions)
 on: workflow_dispatch
+permissions:
+  contents: read
+
 jobs:
   install:
     timeout-minutes: 60


### PR DESCRIPTION
## Details

⚠️ This PR was created by an automated tool. Please review the changes carefully. ⚠️ 

We want to set the default permissions for workflows to read-only for contents. 
This is a security measure to prevent accidental changes to the repository.

This change adds a top-level permissions block to all workflows in the .github/workflows directory.
```yaml
permissions:
  contents: read
```

In some cases workflows might need more permissions than just `contents: read`.
Please checkout this branch and add the necessary permissions to the workflows.

If your workflow uses a Personal Access Token (PAT), we can still add the permissions block,
   but it will not have any effect.

Merging this PR as is might cause workflows that need more permissions to fail.

If there are any questions, please reach out to the @elastic/observablt-ci
