### PR TITLE
github-action: add opentelemetry action and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "22:00"
+    open-pull-requests-limit: 5
+
+  # GitHub actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    reviewers:
+      - "elastic/observablt-ci"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "22:00"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/opentelemetry.yml
+++ b/.github/workflows/opentelemetry.yml
@@ -1,0 +1,22 @@
+---
+# Look up results at https://ela.st/oblt-ci-cd-stats
+# There will be one service per GitHub repository, including the org name, and one Transaction per Workflow.
+name: OpenTelemetry Export Trace
+
+on:
+  workflow_run:
+    workflows: [ "*" ]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  otel-export-trace:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: elastic/apm-pipeline-library/.github/actions/opentelemetry@current
+        with:
+          vaultUrl: ${{ secrets.VAULT_ADDR }}
+          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
+          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}


### PR DESCRIPTION
Keep dependencies up to date with dependabot
Send the GitHub actions steps to the OTEL - to help with visualising the GitHub actions in APM.