### PR TITLE
Set cooldown for Dependabot updates to 14 days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       day: "sunday"
       time: "22:00"
     open-pull-requests-limit: 5
+    cooldown:
+      days: 14
 
   # GitHub actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Added cooldown period for Dependabot updates. See https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-