### PR TITLE
feat: Add network trace collector

### DIFF
--- a/src/helpers/network-trace.ts
+++ b/src/helpers/network-trace.ts
@@ -1,0 +1,281 @@
+import { Page } from '@playwright/test';
+import { randomUUID } from 'crypto';
+import { Logger } from 'winston';
+
+export type NetworkRequestTiming = {
+  requestId: string;
+  url: string;
+  method: string;
+  resourceType?: string;
+  status?: number;
+  mimeType?: string;
+  protocol?: string;
+  fromDiskCache?: boolean;
+  fromServiceWorker?: boolean;
+  encodedDataLength?: number;
+  startTimeEpochMs?: number;
+  ttfbMs?: number;
+  durationMs?: number;
+  finished: boolean;
+  failed?: boolean;
+  errorText?: string;
+};
+
+export type SlowNetworkRequest = Pick<
+  NetworkRequestTiming,
+  'requestId' | 'url' | 'method' | 'resourceType' | 'status' | 'ttfbMs' | 'durationMs' | 'encodedDataLength' | 'failed'
+>;
+
+export type NetworkTraceSummary = {
+  finishedRequests: number;
+  failedRequests: number;
+  inflightRequests: number;
+  droppedRequestStarts: number;
+  totalEncodedDataLength: number;
+};
+
+export type NetworkTraceCapture = {
+  traceId: string;
+  captureStartedAt: string;
+  captureEndedAt: string;
+  maxNetworkRequests: number;
+  summary: NetworkTraceSummary;
+  slowestRequests: SlowNetworkRequest[];
+  requests: NetworkRequestTiming[];
+};
+
+export type NetworkTraceCollectorOptions = {
+  maxNetworkRequests?: number;
+  slowRequestCount?: number;
+};
+
+type InProgressRequest = NetworkRequestTiming & {
+  requestStartTs?: number;
+};
+
+// Keep the report-facing slow-request list small and stable even if the full trace schema grows.
+function toSlowNetworkRequest(request: NetworkRequestTiming): SlowNetworkRequest {
+  return {
+    requestId: request.requestId,
+    url: request.url,
+    method: request.method,
+    resourceType: request.resourceType,
+    status: request.status,
+    ttfbMs: request.ttfbMs,
+    durationMs: request.durationMs,
+    encodedDataLength: request.encodedDataLength,
+    failed: request.failed,
+  };
+}
+
+// Prefer total request duration and use TTFB only as a tie-breaker for equally long requests.
+function bySlowestRequest(left: NetworkRequestTiming, right: NetworkRequestTiming): number {
+  const leftDuration = left.durationMs ?? -1;
+  const rightDuration = right.durationMs ?? -1;
+  if (leftDuration !== rightDuration) {
+    return rightDuration - leftDuration;
+  }
+
+  const leftTtfb = left.ttfbMs ?? -1;
+  const rightTtfb = right.ttfbMs ?? -1;
+  return rightTtfb - leftTtfb;
+}
+
+/**
+ * Creates an opt-in network trace collector backed by the Chrome DevTools Protocol.
+ *
+ * Usage:
+ *   const trace = await createNetworkTraceCollector(page, log);
+ *   await trace.start();             // open a bounded capture window
+ *   await page.reload();             // the navigation or action you want to inspect
+ *   const data = await trace.collect();
+ *   await trace.dispose();           // detach CDP session
+ *
+ * This helper is intended for deeper investigation than the main performance
+ * report. It captures per-request timing details plus a compact slow-request
+ * summary so callers can publish a small correlated report and, when needed,
+ * persist the full request trace separately.
+ */
+export async function createNetworkTraceCollector(
+  page: Page,
+  log: Logger,
+  options: NetworkTraceCollectorOptions = {},
+) {
+  const cdpSession = await page.context().newCDPSession(page);
+  const maxNetworkRequests = options.maxNetworkRequests ?? 1000;
+  const slowRequestCount = options.slowRequestCount ?? 5;
+
+  await cdpSession.send('Network.enable');
+  log.info(
+    `NetworkTrace: CDP session active (maxNetworkRequests=${maxNetworkRequests}, slowRequestCount=${slowRequestCount})`,
+  );
+
+  const inProgress = new Map<string, InProgressRequest>();
+  const completedRequests: NetworkRequestTiming[] = [];
+
+  let activeTraceId: string | null = null;
+  let captureStartedAt: string | null = null;
+  let droppedRequestStarts = 0;
+  let isCapturing = false;
+
+  const shouldDropStart = (requestId: string): boolean => {
+    if (inProgress.has(requestId)) {
+      return false;
+    }
+
+    if (inProgress.size + completedRequests.length >= maxNetworkRequests) {
+      droppedRequestStarts++;
+      return true;
+    }
+
+    return false;
+  };
+
+  cdpSession.on('Network.requestWillBeSent', (event: any) => {
+    if (!isCapturing || !event?.request?.url || !event?.requestId) {
+      return;
+    }
+
+    const requestId: string = event.requestId;
+    if (shouldDropStart(requestId)) {
+      return;
+    }
+
+    const request: InProgressRequest = {
+      requestId,
+      url: event.request.url,
+      method: event.request.method,
+      resourceType: event.type,
+      startTimeEpochMs: typeof event.wallTime === 'number' ? Math.round(event.wallTime * 1000) : undefined,
+      finished: false,
+      requestStartTs: typeof event.timestamp === 'number' ? event.timestamp : undefined,
+    };
+
+    inProgress.set(requestId, request);
+  });
+
+  cdpSession.on('Network.responseReceived', (event: any) => {
+    if (!isCapturing || !event?.requestId) {
+      return;
+    }
+
+    const request = inProgress.get(event.requestId);
+    if (!request) {
+      return;
+    }
+
+    request.status = event?.response?.status;
+    request.mimeType = event?.response?.mimeType;
+    request.protocol = event?.response?.protocol;
+    request.fromDiskCache = event?.response?.fromDiskCache;
+    request.fromServiceWorker = event?.response?.fromServiceWorker;
+
+    if (typeof event.timestamp === 'number' && request.requestStartTs != null) {
+      request.ttfbMs = Math.max(0, Math.round((event.timestamp - request.requestStartTs) * 1000));
+    }
+  });
+
+  cdpSession.on('Network.loadingFinished', (event: any) => {
+    if (!isCapturing || !event?.requestId) {
+      return;
+    }
+
+    const request = inProgress.get(event.requestId);
+    if (!request) {
+      return;
+    }
+
+    if (typeof event.timestamp === 'number' && request.requestStartTs != null) {
+      request.durationMs = Math.max(0, Math.round((event.timestamp - request.requestStartTs) * 1000));
+    }
+    if (typeof event.encodedDataLength === 'number') {
+      request.encodedDataLength = event.encodedDataLength;
+    }
+    request.finished = true;
+
+    const { requestStartTs, ...publicRequest } = request;
+    completedRequests.push(publicRequest);
+    inProgress.delete(event.requestId);
+  });
+
+  cdpSession.on('Network.loadingFailed', (event: any) => {
+    if (!isCapturing || !event?.requestId) {
+      return;
+    }
+
+    const request = inProgress.get(event.requestId);
+    if (!request) {
+      return;
+    }
+
+    if (typeof event.timestamp === 'number' && request.requestStartTs != null) {
+      request.durationMs = Math.max(0, Math.round((event.timestamp - request.requestStartTs) * 1000));
+    }
+    request.finished = true;
+    request.failed = true;
+    request.errorText = event?.errorText;
+
+    const { requestStartTs, ...publicRequest } = request;
+    completedRequests.push(publicRequest);
+    inProgress.delete(event.requestId);
+  });
+
+  return {
+    async start(traceId = randomUUID()) {
+      activeTraceId = traceId;
+      captureStartedAt = new Date().toISOString();
+      droppedRequestStarts = 0;
+      completedRequests.length = 0;
+      inProgress.clear();
+      isCapturing = true;
+      log.info(`NetworkTrace: capture started (traceId=${traceId})`);
+      return traceId;
+    },
+
+    async collect(): Promise<NetworkTraceCapture> {
+      if (!isCapturing || !activeTraceId || !captureStartedAt) {
+        throw new Error('NetworkTrace: collect() called before start(); call start() first to begin a capture window.');
+      }
+
+      isCapturing = false;
+
+      const summary: NetworkTraceSummary = {
+        finishedRequests: completedRequests.length,
+        failedRequests: completedRequests.filter((request) => request.failed === true).length,
+        inflightRequests: inProgress.size,
+        droppedRequestStarts,
+        totalEncodedDataLength: completedRequests.reduce(
+          (total, request) => total + (request.encodedDataLength ?? 0),
+          0,
+        ),
+      };
+
+      const trace: NetworkTraceCapture = {
+        traceId: activeTraceId,
+        captureStartedAt,
+        captureEndedAt: new Date().toISOString(),
+        maxNetworkRequests,
+        summary,
+        slowestRequests: completedRequests
+          .slice()
+          .sort(bySlowestRequest)
+          .slice(0, slowRequestCount)
+          .map(toSlowNetworkRequest),
+        requests: completedRequests.slice(),
+      };
+
+      log.info(
+        `NetworkTrace: capture collected (traceId=${trace.traceId}, finished=${summary.finishedRequests}, failed=${summary.failedRequests}, inflight=${summary.inflightRequests}, dropped=${summary.droppedRequestStarts})`,
+      );
+
+      return trace;
+    },
+
+    async dispose() {
+      await cdpSession.detach();
+      log.info('NetworkTrace: CDP session detached');
+    },
+  };
+}
+
+export type NetworkTraceCollector = Awaited<ReturnType<typeof createNetworkTraceCollector>>;

--- a/src/helpers/perf-metrics.ts
+++ b/src/helpers/perf-metrics.ts
@@ -29,39 +29,42 @@ export async function createPerfCollector(page: Page, log: Logger) {
     },
 
     async collect() {
-      // --- Web Vitals (in-page query) ---
-      const { lcp, fcp } = await page.evaluate(() => {
-        return new Promise<{ lcp: number | null; fcp: number | null }>((resolve) => {
+      // --- Web Vitals + Navigation Timing (single in-page query) ---
+      const { lcpMs, fcpMs, ttfbMs, domContentLoadedMs, loadMs } = await page.evaluate(() => {
+        return new Promise<{
+          lcpMs: number | null;
+          fcpMs: number | null;
+          ttfbMs: number;
+          domContentLoadedMs: number;
+          loadMs: number;
+        }>((resolve) => {
           const paintEntries = performance.getEntriesByType('paint');
-          const fcpEntry = paintEntries.find(e => e.name === 'first-contentful-paint');
-          const fcp = fcpEntry ? Math.round(fcpEntry.startTime) : null;
+          const fcpEntry = paintEntries.find((e) => e.name === 'first-contentful-paint');
+          const fcpMs = fcpEntry ? Math.round(fcpEntry.startTime) : null;
 
-          let lcp: number | null = null;
+          const entries = performance.getEntriesByType('navigation');
+          const nav = (entries[0] as PerformanceNavigationTiming | undefined);
+          const ttfbMs = nav ? Math.round(nav.responseStart - nav.requestStart) : 0;
+          const domContentLoadedMs = nav ? Math.round(nav.domContentLoadedEventEnd - nav.startTime) : 0;
+          const loadMs = nav && nav.loadEventEnd > 0 ? Math.round(nav.loadEventEnd - nav.startTime) : 0;
+
+          let lcpMs: number | null = null;
           try {
             const observer = new PerformanceObserver((list) => {
-              const entries = list.getEntries();
-              if (entries.length > 0) {
-                lcp = Math.round(entries[entries.length - 1].startTime);
+              const lcpEntries = list.getEntries();
+              if (lcpEntries.length > 0) {
+                lcpMs = Math.round(lcpEntries[lcpEntries.length - 1].startTime);
               }
             });
             observer.observe({ type: 'largest-contentful-paint', buffered: true });
-            setTimeout(() => { observer.disconnect(); resolve({ lcp, fcp }); }, 100);
+            setTimeout(() => {
+              observer.disconnect();
+              resolve({ lcpMs, fcpMs, ttfbMs, domContentLoadedMs, loadMs });
+            }, 100);
           } catch {
-            resolve({ lcp: null, fcp });
+            resolve({ lcpMs: null, fcpMs, ttfbMs, domContentLoadedMs, loadMs });
           }
         });
-      });
-
-      // --- Navigation Timing (in-page query) ---
-      const { ttfb, domContentLoaded, load } = await page.evaluate(() => {
-        const entries = performance.getEntriesByType('navigation');
-        if (!entries.length) return { ttfb: 0, domContentLoaded: 0, load: 0 };
-        const nav = entries[0] as PerformanceNavigationTiming;
-        return {
-          ttfb: Math.round(nav.responseStart - nav.requestStart),
-          domContentLoaded: Math.round(nav.domContentLoadedEventEnd - nav.startTime),
-          load: nav.loadEventEnd > 0 ? Math.round(nav.loadEventEnd - nav.startTime) : 0,
-        };
       });
 
       // --- CDP Performance domain (delta from baseline) ---
@@ -74,22 +77,22 @@ export async function createPerfCollector(page: Page, log: Logger) {
       const delta = (name: string) => (current.get(name) ?? 0) - (base.get(name) ?? 0);
 
       const result = {
-        lcp,
-        fcp,
-        ttfb,
-        domContentLoaded,
-        load,
-        scriptDuration: Math.round(delta('ScriptDuration') * 1000),
-        layoutDuration: Math.round(delta('LayoutDuration') * 1000),
-        recalcStyleDuration: Math.round(delta('RecalcStyleDuration') * 1000),
-        taskDuration: Math.round(delta('TaskDuration') * 1000),
-        jsHeapUsedSize: Math.round((current.get('JSHeapUsedSize') ?? 0) / (1024 * 1024)),
+        lcpMs,
+        fcpMs,
+        ttfbMs,
+        domContentLoadedMs,
+        loadMs,
+        scriptDurationMs: Math.round(delta('ScriptDuration') * 1000),
+        layoutDurationMs: Math.round(delta('LayoutDuration') * 1000),
+        recalcStyleDurationMs: Math.round(delta('RecalcStyleDuration') * 1000),
+        taskDurationMs: Math.round(delta('TaskDuration') * 1000),
+        jsHeapUsedSizeMb: Math.round((current.get('JSHeapUsedSize') ?? 0) / (1024 * 1024)),
       };
 
       log.info(
-        `PerfMetrics collected: LCP=${result.lcp ?? 'N/A'}ms, ` +
-        `FCP=${result.fcp ?? 'N/A'}ms, TTFB=${result.ttfb}ms, ` +
-        `DOMContentLoaded=${result.domContentLoaded}ms, Load=${result.load}ms`
+        `PerfMetrics collected: LCP=${result.lcpMs ?? 'N/A'}ms, ` +
+        `FCP=${result.fcpMs ?? 'N/A'}ms, TTFB=${result.ttfbMs}ms, ` +
+        `DOMContentLoaded=${result.domContentLoadedMs}ms, Load=${result.loadMs}ms`
       );
 
       return result;

--- a/src/helpers/reporter.ts
+++ b/src/helpers/reporter.ts
@@ -12,8 +12,33 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { Table } from 'console-table-printer';
 import { Logger } from "winston";
+import { NetworkTraceCapture } from './network-trace';
 
 const outputDirectory = CI === 'true' ? '/home/runner/work/oblt-playwright/' : REPORT_DIR;
+
+function ensureOutputDirectory() {
+  if (!fs.existsSync(outputDirectory)) {
+    fs.mkdirSync(outputDirectory, { recursive: true });
+  }
+}
+
+function buildReportFileBase(testStartTime: string, testTitle: string): string {
+  return `${new Date(testStartTime).toISOString().replace(/:/g, '_')}_${testTitle.replace(/\s/g, "_").toLowerCase()}`;
+}
+
+function buildPeriodLabel() {
+  return ABSOLUTE_TIME_RANGE
+    ? `From ${START_DATE} to ${END_DATE}`
+    : `Last ${TIME_VALUE} ${TIME_UNIT}`;
+}
+
+function stripAnsi(value: string | undefined): string {
+  if (!value) {
+    return '';
+  }
+
+  return value.replace(/\u001b\[[0-9;]*m|\u001b/g, '');
+}
 
 export async function writeJsonReport(
   log: Logger,
@@ -29,12 +54,10 @@ export async function writeJsonReport(
   let cluster_name: any = clusterData.cluster_name;
   let files: string[] = [];
 
-  const fileName = `${new Date(testStartTime).toISOString().replace(/:/g, '_')}_${testInfo.title.replace(/\s/g, "_").toLowerCase()}.json`;
+  const fileName = `${buildReportFileBase(testStartTime, testInfo.title)}.json`;
   files.push(fileName);
 
-  if (!fs.existsSync(outputDirectory)) {
-    fs.mkdirSync(outputDirectory, { recursive: true });
-  }
+  ensureOutputDirectory();
   log.info(`Saving report file to ${outputDirectory}`);
   const outputPath = path.join(outputDirectory, fileName);
 
@@ -42,12 +65,10 @@ export async function writeJsonReport(
     title: testInfo.title,
     startTime: testStartTime,
     doc_count: docsCount,
-    period: ABSOLUTE_TIME_RANGE
-      ? `From ${START_DATE} to ${END_DATE}`
-      : `Last ${TIME_VALUE} ${TIME_UNIT}`,
+    period: buildPeriodLabel(),
     status: testInfo.status,
     duration: testInfo.duration,
-    ...(testInfo.errors.length > 0 && { errors: { message: testInfo.errors.map(e => (e.message ? e.message.replace(/\u001b\[[0-9;]*m|\u001b/g, '') : '')).join('\n') } }),
+    ...(testInfo.errors.length > 0 && { errors: { message: testInfo.errors.map((error) => stripAnsi(error.message)).join('\n') } }),
     cluster_name: cluster_name,
     build_flavor: build_flavor,
     steps: stepData ? stepData : null,
@@ -56,6 +77,43 @@ export async function writeJsonReport(
   };
   fs.writeFileSync(outputPath, JSON.stringify(reportData, null, 2));
   return files;
+}
+
+export async function writeNetworkTraceReport(
+  log: Logger,
+  clusterData: any,
+  testInfo: TestInfo,
+  testStartTime: string,
+  networkTrace: NetworkTraceCapture,
+  perfMetrics?: object,
+) {
+  ensureOutputDirectory();
+
+  const fileName = `${buildReportFileBase(testStartTime, testInfo.title)}.network-trace.json`;
+  const outputPath = path.join(outputDirectory, fileName);
+
+  const traceReportData = {
+    title: testInfo.title,
+    startTime: testStartTime,
+    period: buildPeriodLabel(),
+    status: testInfo.status,
+    duration: testInfo.duration,
+    ...(testInfo.errors.length > 0 && { errors: { message: testInfo.errors.map((error) => stripAnsi(error.message)).join('\n') } }),
+    cluster_name: clusterData.cluster_name,
+    build_flavor: clusterData.version.build_flavor,
+    networkTraceId: networkTrace.traceId,
+    performanceMetrics: perfMetrics,
+    networkSummary: networkTrace.summary,
+    slowestRequests: networkTrace.slowestRequests,
+    captureStartedAt: networkTrace.captureStartedAt,
+    captureEndedAt: networkTrace.captureEndedAt,
+    maxNetworkRequests: networkTrace.maxNetworkRequests,
+    requests: networkTrace.requests,
+  };
+
+  log.info(`Saving network trace file to ${outputPath}`);
+  fs.writeFileSync(outputPath, JSON.stringify(traceReportData, null, 2));
+  return fileName;
 }
 
 export async function printResults(reportFiles: string[]) {
@@ -124,18 +182,45 @@ export async function printResults(reportFiles: string[]) {
 
           const ms = (v: any) => v != null ? `${v} ms` : 'N/A';
           perfTable.addRows([
-            { metric: 'LCP (Largest Contentful Paint)', value: ms(pm.lcp) },
-            { metric: 'FCP (First Contentful Paint)', value: ms(pm.fcp) },
-            { metric: 'TTFB (Time to First Byte)', value: ms(pm.ttfb) },
-            { metric: 'DOM Content Loaded', value: ms(pm.domContentLoaded) },
-            { metric: 'Page Load', value: ms(pm.load) },
-            { metric: 'Script Duration', value: ms(pm.scriptDuration) },
-            { metric: 'Layout Duration', value: ms(pm.layoutDuration) },
-            { metric: 'Recalc Style Duration', value: ms(pm.recalcStyleDuration) },
-            { metric: 'Task Duration', value: ms(pm.taskDuration) },
-            { metric: 'JS Heap Used', value: pm.jsHeapUsedSize != null ? `${pm.jsHeapUsedSize} MB` : 'N/A' },
+            { metric: 'LCP (Largest Contentful Paint)', value: ms(pm.lcpMs) },
+            { metric: 'FCP (First Contentful Paint)', value: ms(pm.fcpMs) },
+            { metric: 'TTFB (Time to First Byte)', value: ms(pm.ttfbMs) },
+            { metric: 'DOM Content Loaded', value: ms(pm.domContentLoadedMs) },
+            { metric: 'Page Load', value: ms(pm.loadMs) },
+            { metric: 'Script Duration', value: ms(pm.scriptDurationMs) },
+            { metric: 'Layout Duration', value: ms(pm.layoutDurationMs) },
+            { metric: 'Recalc Style Duration', value: ms(pm.recalcStyleDurationMs) },
+            { metric: 'Task Duration', value: ms(pm.taskDurationMs) },
+            { metric: 'JS Heap Used', value: pm.jsHeapUsedSizeMb != null ? `${pm.jsHeapUsedSizeMb} MB` : 'N/A' },
+            { metric: 'Network Trace Id', value: pm.networkTraceId ?? 'N/A' },
+            { metric: 'Finished Requests', value: pm.networkSummary?.finishedRequests != null ? String(pm.networkSummary.finishedRequests) : 'N/A' },
+            { metric: 'Failed Requests', value: pm.networkSummary?.failedRequests != null ? String(pm.networkSummary.failedRequests) : 'N/A' },
+            { metric: 'Dropped Requests', value: pm.networkSummary?.droppedRequestStarts != null ? String(pm.networkSummary.droppedRequestStarts) : 'N/A' },
           ], { separator: true });
           perfTable.printTable();
+
+          if (Array.isArray(pm.slowestRequests) && pm.slowestRequests.length > 0) {
+            const slowRequestsTable = new Table({
+              title: `Slowest Network Requests`,
+              columns: [
+                { name: 'method', title: 'Method', color: 'yellow' },
+                { name: 'status', title: 'Status' },
+                { name: 'duration', title: 'Duration', color: 'green' },
+                { name: 'url', title: 'URL', maxLen: 80 },
+              ],
+            });
+
+            slowRequestsTable.addRows(
+              pm.slowestRequests.map((request: any) => ({
+                method: request.method,
+                status: request.status ?? 'N/A',
+                duration: request.durationMs != null ? `${request.durationMs} ms` : 'N/A',
+                url: request.url,
+              })),
+              { separator: true },
+            );
+            slowRequestsTable.printTable();
+          }
         }
 
       } catch (innerError: any) {

--- a/src/helpers/setup.ts
+++ b/src/helpers/setup.ts
@@ -5,6 +5,7 @@ import {
 } from '../env.ts';
 import {
   oblt_playwright,
+  oblt_playwright_network_traces,
   oblt_playwright_logs
 } from '../index-templates.ts';
 import { Logger } from "winston";
@@ -60,6 +61,9 @@ export async function createIndexTemplate(name: string) {
     case "oblt-playwright":
         template_name = oblt_playwright;
         break;
+    case "oblt-playwright-network-traces":
+      template_name = oblt_playwright_network_traces;
+      break;
     case "playwright-logs":
         template_name = oblt_playwright_logs;
         break;

--- a/src/index-templates.ts
+++ b/src/index-templates.ts
@@ -1,3 +1,63 @@
+const requestTimingProperties = {
+  requestId: { type: 'keyword' },
+  url: { type: 'keyword' },
+  method: { type: 'keyword' },
+  resourceType: { type: 'keyword' },
+  status: { type: 'short' },
+  mimeType: { type: 'keyword' },
+  protocol: { type: 'keyword' },
+  fromDiskCache: { type: 'boolean' },
+  fromServiceWorker: { type: 'boolean' },
+  encodedDataLength: { type: 'long' },
+  startTimeEpochMs: { type: 'date' },
+  ttfbMs: { type: 'long' },
+  durationMs: { type: 'long' },
+  finished: { type: 'boolean' },
+  failed: { type: 'boolean' },
+  errorText: { type: 'keyword' },
+};
+
+const networkSummaryProperties = {
+  finishedRequests: { type: 'long' },
+  failedRequests: { type: 'long' },
+  inflightRequests: { type: 'long' },
+  droppedRequestStarts: { type: 'long' },
+  totalEncodedDataLength: { type: 'long' },
+};
+
+const slowRequestProperties = {
+  requestId: { type: 'keyword' },
+  url: { type: 'keyword' },
+  method: { type: 'keyword' },
+  resourceType: { type: 'keyword' },
+  status: { type: 'short' },
+  ttfbMs: { type: 'long' },
+  durationMs: { type: 'long' },
+  encodedDataLength: { type: 'long' },
+  failed: { type: 'boolean' },
+};
+
+const performanceMetricsProperties = {
+  lcpMs: { type: 'long' },
+  fcpMs: { type: 'long' },
+  ttfbMs: { type: 'long' },
+  domContentLoadedMs: { type: 'long' },
+  loadMs: { type: 'long' },
+  scriptDurationMs: { type: 'long' },
+  layoutDurationMs: { type: 'long' },
+  recalcStyleDurationMs: { type: 'long' },
+  taskDurationMs: { type: 'long' },
+  jsHeapUsedSizeMb: { type: 'long' },
+  networkTraceId: { type: 'keyword' },
+  networkSummary: {
+    properties: networkSummaryProperties,
+  },
+  slowestRequests: {
+    type: 'nested',
+    properties: slowRequestProperties,
+  },
+};
+
 export const oblt_playwright = {
       mappings: {
         properties: {
@@ -72,20 +132,42 @@ export const oblt_playwright = {
           },
           cacheStats: { type: 'object' },
           performanceMetrics: {
-            properties: {
-              lcp: { type: 'long' },
-              fcp: { type: 'long' },
-              ttfb: { type: 'long' },
-              domContentLoaded: { type: 'long' },
-              load: { type: 'long' },
-              scriptDuration: { type: 'long' },
-              layoutDuration: { type: 'long' },
-              recalcStyleDuration: { type: 'long' },
-              taskDuration: { type: 'long' },
-              jsHeapUsedSize: { type: 'long' },
-            },
+            properties: performanceMetricsProperties,
           },
           measurements: { type: 'object' },
+        },
+      },
+    }
+
+export const oblt_playwright_network_traces = {
+      mappings: {
+        properties: {
+          title: { type: 'text' },
+          startTime: { type: 'date' },
+          period: { type: 'keyword' },
+          status: { type: 'keyword' },
+          duration: { type: 'float' },
+          errors: { type: 'object' },
+          cluster_name: { type: 'keyword' },
+          build_flavor: { type: 'keyword' },
+          networkTraceId: { type: 'keyword' },
+          captureStartedAt: { type: 'date' },
+          captureEndedAt: { type: 'date' },
+          maxNetworkRequests: { type: 'long' },
+          performanceMetrics: {
+            properties: performanceMetricsProperties,
+          },
+          networkSummary: {
+            properties: networkSummaryProperties,
+          },
+          slowestRequests: {
+            type: 'nested',
+            properties: slowRequestProperties,
+          },
+          requests: {
+            type: 'nested',
+            properties: requestTimingProperties,
+          },
         },
       },
     }

--- a/src/utils/upload-to-es.sh
+++ b/src/utils/upload-to-es.sh
@@ -3,10 +3,16 @@
 REPORT_DIR="${REPORT_DIR:-/home/runner/work/oblt-playwright/}"
 REPORT_CLUSTER_ES=${REPORT_CLUSTER_ES%/}
 
-FILES=$(find "$REPORT_DIR" -type f -name "20*.json" ! -name "results.json" ! -name "package.json" ! -name "package-lock.json")
+FILES=$(find "$REPORT_DIR" -type f -name "20*.json" ! -name "*.network-trace.json" ! -name "results.json" ! -name "package.json" ! -name "package-lock.json")
 for file in $FILES; do
     echo "Found file: $file"
     curl -XPOST "$REPORT_CLUSTER_ES/oblt-playwright/_doc/?pretty" -H "Authorization: ApiKey $REPORT_CLUSTER_API_KEY" -H "Content-Type: application/json" --data-binary "@$file"
+done
+
+TRACE_FILES=$(find "$REPORT_DIR" -type f -name "*.network-trace.json")
+for trace_file in $TRACE_FILES; do
+    echo "Found network trace file: $trace_file"
+    curl -XPOST "$REPORT_CLUSTER_ES/oblt-playwright-network-traces/_doc/?pretty" -H "Authorization: ApiKey $REPORT_CLUSTER_API_KEY" -H "Content-Type: application/json" --data-binary "@$trace_file"
 done
 
 LOG_FILES=$(find "$REPORT_DIR" -type f -name "execution.json.log")

--- a/tests/bb/discover.bb.spec.ts
+++ b/tests/bb/discover.bb.spec.ts
@@ -1,8 +1,9 @@
 import * as fs from 'fs';
 import { test } from '../../src/pom/page-fixtures';
+import { createNetworkTraceCollector, NetworkTraceCapture } from '../../src/helpers/network-trace';
 import { testStep, buildKibanaUrl } from '../../src/helpers/test-utils';
 import { fetchClusterData, getDocCount, listDataViews } from '../../src/helpers/api-client';
-import { writeJsonReport, printResults } from '../../src/helpers/reporter';
+import { writeJsonReport, writeNetworkTraceReport, printResults } from '../../src/helpers/reporter';
 
 interface Scenario {
   name: string;
@@ -81,11 +82,15 @@ for (const scenario of scenarios) {
 
     test.afterEach('Log test results', async ({ log }, testInfo) => {
       const perfData = (testInfo as any).perfData;
+      const networkTrace = (testInfo as any).networkTrace as NetworkTraceCapture | null | undefined;
       const stepData = (testInfo as any).stepData;
       const reportFiles = await writeJsonReport(
         log, clusterData, testInfo, testStartTime, doc_count,
         stepData, undefined, perfData
       );
+      if (networkTrace) {
+        await writeNetworkTraceReport(log, clusterData, testInfo, testStartTime, networkTrace, perfData ?? undefined);
+      }
       reports.push(...reportFiles.filter(item => typeof item === 'string'));
     });
 
@@ -106,56 +111,87 @@ for (const scenario of scenarios) {
       : `Opening ${KIBANA_APP_PATH} with url-embedded _a target and collecting full navigation metrics`;
 
     test(testName,
-      async ({ discoverPage, headerBar, notifications, perfMetrics, page, log }, testInfo) => {
+      async ({ discoverPage, notifications, perfMetrics, page, log }, testInfo) => {
         let stepData: object[] = [];
         let perfData: object | null = null;
+        let networkTrace: NetworkTraceCapture | null = null;
+        let traceCollectionStarted = false;
         (testInfo as any).stepData = stepData;
         (testInfo as any).perfData = perfData;
+        (testInfo as any).networkTrace = networkTrace;
 
-        await testStep('step01', stepData, page, async () => {
-          let appState: string;
-          const { appPath, appState: urlAppState } = getUrlEmbeddedAppState(KIBANA_APP_PATH);
-          if (DATA_VIEW_TITLE) {
-            if (!dataViewId) {
-              throw new Error(`Data view id was not resolved for data_view "${DATA_VIEW_TITLE}"`);
+        const networkTraceCollector = await createNetworkTraceCollector(page, log, {
+          maxNetworkRequests: 2000,
+          slowRequestCount: 5,
+        });
+
+        try {
+          await testStep('step01', stepData, page, async () => {
+            let appState: string;
+            const { appPath, appState: urlAppState } = getUrlEmbeddedAppState(KIBANA_APP_PATH);
+            if (DATA_VIEW_TITLE) {
+              if (!dataViewId) {
+                throw new Error(`Data view id was not resolved for data_view "${DATA_VIEW_TITLE}"`);
+              }
+              appState = `(index:'${dataViewId}')`;
+            } else if (urlAppState) {
+              appState = normalizeTarget(urlAppState);
+            } else {
+              throw new Error('Neither DATA_VIEW_TITLE nor a url-embedded _a target are configured');
             }
-            appState = `(index:'${dataViewId}')`;
-          } else if (urlAppState) {
-            appState = normalizeTarget(urlAppState);
-          } else {
-            throw new Error('Neither DATA_VIEW_TITLE nor a url-embedded _a target are configured');
+
+            const kibanaUrl = buildKibanaUrl(appPath, appState);
+            log.info(logNavigate);
+            await perfMetrics.takeBaseline();
+            await networkTraceCollector.start();
+            traceCollectionStarted = true;
+            await page.goto(kibanaUrl);
+            const loadingIndicator = page.locator('[data-test-subj="globalLoadingIndicator"]');
+            await loadingIndicator.waitFor({ state: 'visible', timeout: 2000 }).catch(() => {});
+            await loadingIndicator.waitFor({ state: 'hidden', timeout: 180000 });
+
+            log.info('Asserting visibility of the chart canvas and data grid row');
+            await Promise.race([
+              discoverPage.assertVisibilityDataGridRow(),
+              notifications.assertErrorFetchingResource().then(() => {
+                throw new Error('Test is failed: Error while fetching resource');
+              }),
+              notifications.assertErrorIncrementCount().then(() => {
+                throw new Error(`Test is failed: Error loading data in index logs-*. already closed, can't increment ref count`);
+              }),
+              discoverPage.assertHistogramEmbeddedError().then(() => {
+                throw new Error('Test is failed: Chart failed to load');
+              }),
+              discoverPage.assertDiscoverNoResults().then(() => {
+                throw new Error('Test is failed: Discover shows no results');
+              }),
+            ]);
+
+            log.info('Step 1 settled, collecting full performance metrics');
+            const collectedPerfMetrics = await perfMetrics.collect();
+            networkTrace = await networkTraceCollector.collect();
+            traceCollectionStarted = false;
+
+            perfData = {
+              ...collectedPerfMetrics,
+              networkTraceId: networkTrace.traceId,
+              networkSummary: networkTrace.summary,
+              slowestRequests: networkTrace.slowestRequests,
+            };
+            (testInfo as any).perfData = perfData;
+            (testInfo as any).networkTrace = networkTrace;
+          }, stepDescription);
+        } finally {
+          if (traceCollectionStarted && !networkTrace) {
+            try {
+              networkTrace = await networkTraceCollector.collect();
+              (testInfo as any).networkTrace = networkTrace;
+            } catch (error: any) {
+              log.warn(`Network trace collection could not be completed: ${error.message}`);
+            }
           }
-
-          const kibanaUrl = buildKibanaUrl(appPath, appState);
-          log.info(logNavigate);
-          await page.goto(kibanaUrl);
-
-          await perfMetrics.takeBaseline();
-          const loadingIndicator = page.locator('[data-test-subj="globalLoadingIndicator"]');
-          await loadingIndicator.waitFor({ state: 'visible', timeout: 2000 }).catch(() => {});
-          await loadingIndicator.waitFor({ state: 'hidden', timeout: 180000 });
-
-          log.info('Asserting visibility of the chart canvas and data grid row');
-          await Promise.race([
-            discoverPage.assertVisibilityDataGridRow(),
-            notifications.assertErrorFetchingResource().then(() => {
-              throw new Error('Test is failed: Error while fetching resource');
-            }),
-            notifications.assertErrorIncrementCount().then(() => {
-              throw new Error(`Test is failed: Error loading data in index logs-*. already closed, can't increment ref count`);
-            }),
-            discoverPage.assertHistogramEmbeddedError().then(() => {
-              throw new Error('Test is failed: Chart failed to load');
-            }),
-            discoverPage.assertDiscoverNoResults().then(() => {
-              throw new Error('Test is failed: Discover shows no results');
-            }),
-          ]);
-
-          log.info('Step 1 settled, collecting full performance metrics');
-          perfData = await perfMetrics.collect();
-          (testInfo as any).perfData = perfData;
-        }, stepDescription);
+          await networkTraceCollector.dispose();
+        }
       });
   });
 }

--- a/tests/preflight-check.ts
+++ b/tests/preflight-check.ts
@@ -80,6 +80,7 @@ test.describe('Preflight checks', () => {
     test.skip("Reporting cluster check", async ({ log }) => {
         const indices: string[] = [
             'oblt-playwright',
+            'oblt-playwright-network-traces',
             'playwright-logs'
         ];
 


### PR DESCRIPTION
Resolves https://github.com/elastic/oblt-playwright/issues/452

## Summary

This PR adds opt-in network trace collection for benchmark runs.

Benchmarks can now capture per-request timing details alongside the existing page-level performance metrics, which makes it easier to investigate slow navigations, backend latency, and request-heavy regressions. The main benchmark report keeps a compact summary for quick review, while the full request trace is stored separately and linked through a shared trace id.

## Why

Page-level metrics such as LCP, FCP, TTFB, and load time are useful for detecting regressions, but they do not explain which requests contributed to them.

This change adds a request-level view for benchmarks that need deeper diagnosis, without making the default report noisy or overly expensive to store.

## What Changed

### New network trace capability

- Added a dedicated network trace collector based on the Chrome DevTools Protocol.
- Captured per-request timing details including request metadata, TTFB, total duration, cache/service-worker hints, transfer size, and failure information.
- Added bounded trace collection controls such as `maxNetworkRequests`.
- Added a compact `slowestRequests` view to surface the most relevant requests directly in benchmark output.

### Reporting and correlation

- Extended benchmark performance output with:
  - `networkTraceId`
  - `networkSummary`
  - `slowestRequests`
- Wrote the full request trace to a separate `*.network-trace.json` artifact.
- Linked the compact report and the full trace through `networkTraceId` so investigation can move from summary to detail without ambiguity.

### Storage and indexing

- Added a dedicated Elasticsearch index template for network trace documents.
- Updated upload flow to send:
  - benchmark reports to the main benchmark index
  - full request traces to a dedicated network traces index
  - Playwright execution logs to the existing logs index
- Added the new trace index to the reporting-cluster preflight check.

### Benchmark integration

- Wired the Discover benchmark to opt into trace collection explicitly.
- Scoped trace capture to the measured navigation window instead of enabling it through shared fixtures.
- Kept performance collection focused on page-level metrics and runtime counters.

### Metric naming cleanup

- Renamed performance metric fields to include explicit units, such as `*Ms` and `*Mb`, to make the schema easier to read and less error-prone for downstream consumers.