### PR TITLE
feat: stabilize Hosts measurements and improve network trace reporting

### DIFF
--- a/docs/bb-scenario-runners/hosts-benchmark-overview.md
+++ b/docs/bb-scenario-runners/hosts-benchmark-overview.md
@@ -1,0 +1,66 @@
+# Hosts Benchmark Test Overview
+
+## Purpose
+
+This test measures how fast the Kibana **Hosts** page renders and becomes usable for a defined scenario (time range, host limit, and zoom).
+
+It is designed to produce **stable, comparable** results across runs and scenarios.
+
+## What the test validates
+
+For each Hosts scenario, the test confirms that:
+
+- The page opens with the intended scenario state (time range + host limit).
+- Core visual elements are visible and populated:
+  - host table
+  - KPI cards
+  - key charts
+- No known data-loading error state is shown.
+
+## How measurement is conducted
+
+The test intentionally separates **setup/warm-up** from the **measured window**.
+
+### 1) Setup and state stabilization (not measured)
+
+Before timing starts, the test:
+
+- Opens Hosts once to let Kibana generate its canonical URL state.
+- Rewrites URL state to the desired scenario values (`dateRange`, `limit`).
+- Performs one full warm-up navigation to that desired URL.
+- Waits until all required visualizations are fully rendered.
+
+This stage exists because Kibana may rewrite URL state during boot and may load one-time assets/endpoints on first access. Including that in measurements would add noise and reduce comparability.
+
+### 2) Measured navigation
+
+Only after warm-up is complete, the test starts measurement:
+
+- Takes performance baseline snapshot.
+- Starts network trace capture.
+- Navigates again to the **same desired URL**.
+- Waits for:
+  - loading completion,
+  - correct URL state,
+  - full visualization readiness.
+
+Then it collects performance and network data.
+
+## What is measured
+
+The report includes:
+
+- Browser timing metrics (for example LCP, FCP, TTFB, DOM Content Loaded, Page Load).
+- Runtime work metrics (script, layout, style recalculation, task duration, JS heap).
+- Network summary (finished/failed requests).
+- Slowest requests, split into:
+  - API requests
+  - static assets
+
+This split helps separate backend/data latency from static asset/cache effects.
+
+## Why this approach is used
+
+This benchmark targets **returning-user performance** (realistic day-to-day usage), not first-ever cold start.
+
+By warming up first and measuring the second navigation, the test minimizes one-time startup effects and focuses on scenario-specific render cost. This makes trend tracking and scenario comparison reliable for decision-making.

--- a/src/helpers/network-trace.ts
+++ b/src/helpers/network-trace.ts
@@ -21,10 +21,18 @@ export type NetworkRequestTiming = {
   errorText?: string;
 };
 
+// `api`     — Document, XHR, Fetch, EventSource. Dynamic, server-computed,
+//              not disk-cached. The signal we typically care about for
+//              backend-driven benchmarks.
+// `static`  — Script, Stylesheet, Font, Image, Media, Manifest, TextTrack.
+//              Cacheable. Run-to-run variance is dominated by disk cache state.
+// `other`   — anything else (WebSocket, Ping, Preflight, Other, ...).
+export type NetworkRequestCategory = 'api' | 'static' | 'other';
+
 export type SlowNetworkRequest = Pick<
   NetworkRequestTiming,
-  'requestId' | 'url' | 'method' | 'resourceType' | 'status' | 'ttfbMs' | 'durationMs' | 'encodedDataLength' | 'failed'
->;
+  'requestId' | 'url' | 'method' | 'resourceType' | 'status' | 'ttfbMs' | 'durationMs' | 'encodedDataLength' | 'failed' | 'fromDiskCache'
+> & { category: NetworkRequestCategory };
 
 export type NetworkTraceSummary = {
   finishedRequests: number;
@@ -40,7 +48,13 @@ export type NetworkTraceCapture = {
   captureEndedAt: string;
   maxNetworkRequests: number;
   summary: NetworkTraceSummary;
+  // Top-N slowest across all categories (kept for backward compatibility).
   slowestRequests: SlowNetworkRequest[];
+  // Top-N slowest within each category. Stratifying makes the report stable
+  // across runs: API performance and asset-cache effects can be inspected
+  // independently rather than fighting for the same top-N slots.
+  slowestApiRequests: SlowNetworkRequest[];
+  slowestStaticRequests: SlowNetworkRequest[];
   requests: NetworkRequestTiming[];
 };
 
@@ -53,6 +67,18 @@ type InProgressRequest = NetworkRequestTiming & {
   requestStartTs?: number;
 };
 
+const API_RESOURCE_TYPES = new Set(['Document', 'XHR', 'Fetch', 'EventSource']);
+const STATIC_RESOURCE_TYPES = new Set([
+  'Script', 'Stylesheet', 'Font', 'Image', 'Media', 'Manifest', 'TextTrack',
+]);
+
+function categorizeRequest(resourceType: string | undefined): NetworkRequestCategory {
+  if (!resourceType) return 'other';
+  if (API_RESOURCE_TYPES.has(resourceType)) return 'api';
+  if (STATIC_RESOURCE_TYPES.has(resourceType)) return 'static';
+  return 'other';
+}
+
 // Keep the report-facing slow-request list small and stable even if the full trace schema grows.
 function toSlowNetworkRequest(request: NetworkRequestTiming): SlowNetworkRequest {
   return {
@@ -61,10 +87,12 @@ function toSlowNetworkRequest(request: NetworkRequestTiming): SlowNetworkRequest
     method: request.method,
     resourceType: request.resourceType,
     status: request.status,
+    fromDiskCache: request.fromDiskCache,
     ttfbMs: request.ttfbMs,
     durationMs: request.durationMs,
     encodedDataLength: request.encodedDataLength,
     failed: request.failed,
+    category: categorizeRequest(request.resourceType),
   };
 }
 
@@ -250,17 +278,24 @@ export async function createNetworkTraceCollector(
         ),
       };
 
+      const sortedSlow = completedRequests
+        .slice()
+        .sort(bySlowestRequest)
+        .map(toSlowNetworkRequest);
+
       const trace: NetworkTraceCapture = {
         traceId: activeTraceId,
         captureStartedAt,
         captureEndedAt: new Date().toISOString(),
         maxNetworkRequests,
         summary,
-        slowestRequests: completedRequests
-          .slice()
-          .sort(bySlowestRequest)
-          .slice(0, slowRequestCount)
-          .map(toSlowNetworkRequest),
+        slowestRequests: sortedSlow.slice(0, slowRequestCount),
+        slowestApiRequests: sortedSlow
+          .filter((request) => request.category === 'api')
+          .slice(0, slowRequestCount),
+        slowestStaticRequests: sortedSlow
+          .filter((request) => request.category === 'static')
+          .slice(0, slowRequestCount),
         requests: completedRequests.slice(),
       };
 

--- a/src/helpers/reporter.ts
+++ b/src/helpers/reporter.ts
@@ -40,6 +40,54 @@ function stripAnsi(value: string | undefined): string {
   return value.replace(/\u001b\[[0-9;]*m|\u001b/g, '');
 }
 
+// Strips the origin (scheme + host + optional port) from a URL so the report
+// shows just `/path?query`. Host-agnostic — works for any cluster, not just
+// localhost. Falls back to the raw URL if it isn't parseable.
+function stripUrlOrigin(url: string | undefined): string {
+  if (!url) {
+    return '';
+  }
+  try {
+    const parsed = new URL(url);
+    return `${parsed.pathname}${parsed.search}`;
+  } catch {
+    return url;
+  }
+}
+
+// Renders a slowest-requests table with Type and Cache columns. The Cache
+// column shows `disk` for `fromDiskCache: true` so a reader can immediately
+// see whether a fast/slow result is explained by cache state rather than
+// real backend behaviour. Skips silently if there are no rows.
+function printSlowestRequestsTable(title: string, requests: any[] | undefined) {
+  if (!Array.isArray(requests) || requests.length === 0) {
+    return;
+  }
+  const table = new Table({
+    title,
+    columns: [
+      { name: 'method', title: 'Method', color: 'yellow' },
+      { name: 'status', title: 'Status' },
+      { name: 'type', title: 'Type' },
+      { name: 'cache', title: 'Cache' },
+      { name: 'duration', title: 'Duration', color: 'green' },
+      { name: 'url', title: 'URL', maxLen: 80 },
+    ],
+  });
+  table.addRows(
+    requests.map((request: any) => ({
+      method: request.method,
+      status: request.status ?? 'N/A',
+      type: request.resourceType ?? 'N/A',
+      cache: request.fromDiskCache ? 'disk' : '',
+      duration: request.durationMs != null ? `${request.durationMs} ms` : 'N/A',
+      url: stripUrlOrigin(request.url),
+    })),
+    { separator: true },
+  );
+  table.printTable();
+}
+
 export async function writeJsonReport(
   log: Logger,
   clusterData: any,
@@ -199,27 +247,19 @@ export async function printResults(reportFiles: string[]) {
           ], { separator: true });
           perfTable.printTable();
 
-          if (Array.isArray(pm.slowestRequests) && pm.slowestRequests.length > 0) {
-            const slowRequestsTable = new Table({
-              title: `Slowest Network Requests`,
-              columns: [
-                { name: 'method', title: 'Method', color: 'yellow' },
-                { name: 'status', title: 'Status' },
-                { name: 'duration', title: 'Duration', color: 'green' },
-                { name: 'url', title: 'URL', maxLen: 80 },
-              ],
-            });
-
-            slowRequestsTable.addRows(
-              pm.slowestRequests.map((request: any) => ({
-                method: request.method,
-                status: request.status ?? 'N/A',
-                duration: request.durationMs != null ? `${request.durationMs} ms` : 'N/A',
-                url: request.url,
-              })),
-              { separator: true },
-            );
-            slowRequestsTable.printTable();
+          // Stratify the slowest-requests output into API and static-asset
+          // tables. The API table is the stable cross-run signal (Kibana
+          // API responses are not disk-cached); the static-asset table is
+          // informational and will naturally vary depending on browser
+          // cache state. Fall back to the unified `slowestRequests` when
+          // a report was generated before stratification was added.
+          const hasStratified =
+            Array.isArray(pm.slowestApiRequests) || Array.isArray(pm.slowestStaticRequests);
+          if (hasStratified) {
+            printSlowestRequestsTable('Slowest API Requests', pm.slowestApiRequests);
+            printSlowestRequestsTable('Slowest Static Assets', pm.slowestStaticRequests);
+          } else {
+            printSlowestRequestsTable('Slowest Network Requests', pm.slowestRequests);
           }
         }
 

--- a/src/helpers/test-utils.ts
+++ b/src/helpers/test-utils.ts
@@ -110,31 +110,45 @@ const TIME_UNIT_MAP: Record<string, string> = {
 };
 
 /**
+ * Resolves a Kibana time range from environment variables and returns it as
+ * Rison-ready `from`/`to` strings (e.g. `now-15m` / `now` for relative, or
+ * `'2025-01-01T00:00:00.000Z'` / `'2025-01-02T00:00:00.000Z'` for absolute).
+ *
+ * Priority:
+ *   1. ABSOLUTE_TIME_RANGE + START_DATE + END_DATE (absolute)
+ *   2. TIME_VALUE + TIME_UNIT (relative)
+ *   3. Default: last 15 minutes
+ *
+ * Use this when you need the raw `from`/`to` values to inject into an
+ * app-specific URL state (e.g. Hosts' `_a.dateRange`). For the standard
+ * Kibana hash-routed `_g.time` URL shape, prefer `buildKibanaUrl`.
+ */
+export function resolveKibanaTimeRangeRison(): { from: string; to: string } {
+  if (ABSOLUTE_TIME_RANGE && START_DATE && END_DATE) {
+    return { from: `'${START_DATE}'`, to: `'${END_DATE}'` };
+  }
+  if (TIME_VALUE && TIME_UNIT) {
+    const shortUnit = TIME_UNIT_MAP[TIME_UNIT] || TIME_UNIT;
+    return { from: `now-${TIME_VALUE}${shortUnit}`, to: 'now' };
+  }
+  return { from: 'now-15m', to: 'now' };
+}
+
+/**
  * Builds a Kibana app URL with optional app state (_a) and global time range (_g)
- * encoded in Kibana Rison query params.
+ * encoded as hash params. Suitable for apps that use hash-based routing AND read
+ * time range from `_g.time` (e.g. Discover). NOT suitable for the Hosts app,
+ * which uses query-string routing and persists time range at `_a.dateRange`.
+ *
  * Uses environment variables (START_DATE/END_DATE or TIME_VALUE/TIME_UNIT) by default.
  * @param appPath - Kibana app path, e.g. '/app/discover'
  * @param appState - Optional Kibana app state, e.g. "(index:'<data-view-id>')"
  */
 export function buildKibanaUrl(appPath: string, appState?: string): string {
-  let timeFrom: string;
-  let timeTo: string;
-
-  if (ABSOLUTE_TIME_RANGE && START_DATE && END_DATE) {
-    timeFrom = `'${START_DATE}'`;
-    timeTo = `'${END_DATE}'`;
-  } else if (TIME_VALUE && TIME_UNIT) {
-    const shortUnit = TIME_UNIT_MAP[TIME_UNIT] || TIME_UNIT;
-    timeFrom = `now-${TIME_VALUE}${shortUnit}`;
-    timeTo = 'now';
-  } else {
-    timeFrom = 'now-15m';
-    timeTo = 'now';
-  }
-
+  const { from, to } = resolveKibanaTimeRangeRison();
   const appPathNormalized = appPath.replace(/#\/?\?.*$/, '');
   const appStatePart = appState ? `_a=${appState}&` : '';
-  return `${appPathNormalized}#/?${appStatePart}_g=(time:(from:${timeFrom},to:${timeTo}))`;
+  return `${appPathNormalized}#/?${appStatePart}_g=(time:(from:${from},to:${to}))`;
 }
 
 export async function checkKibanaAvailability(page: Page) {

--- a/src/index-templates.ts
+++ b/src/index-templates.ts
@@ -30,7 +30,9 @@ const slowRequestProperties = {
   url: { type: 'keyword' },
   method: { type: 'keyword' },
   resourceType: { type: 'keyword' },
+  category: { type: 'keyword' },
   status: { type: 'short' },
+  fromDiskCache: { type: 'boolean' },
   ttfbMs: { type: 'long' },
   durationMs: { type: 'long' },
   encodedDataLength: { type: 'long' },
@@ -53,6 +55,14 @@ const performanceMetricsProperties = {
     properties: networkSummaryProperties,
   },
   slowestRequests: {
+    type: 'nested',
+    properties: slowRequestProperties,
+  },
+  slowestApiRequests: {
+    type: 'nested',
+    properties: slowRequestProperties,
+  },
+  slowestStaticRequests: {
     type: 'nested',
     properties: slowRequestProperties,
   },
@@ -161,6 +171,14 @@ export const oblt_playwright_network_traces = {
             properties: networkSummaryProperties,
           },
           slowestRequests: {
+            type: 'nested',
+            properties: slowRequestProperties,
+          },
+          slowestApiRequests: {
+            type: 'nested',
+            properties: slowRequestProperties,
+          },
+          slowestStaticRequests: {
             type: 'nested',
             properties: slowRequestProperties,
           },

--- a/tests/bb/discover.bb.spec.ts
+++ b/tests/bb/discover.bb.spec.ts
@@ -177,6 +177,8 @@ for (const scenario of scenarios) {
               networkTraceId: networkTrace.traceId,
               networkSummary: networkTrace.summary,
               slowestRequests: networkTrace.slowestRequests,
+              slowestApiRequests: networkTrace.slowestApiRequests,
+              slowestStaticRequests: networkTrace.slowestStaticRequests,
             };
             (testInfo as any).perfData = perfData;
             (testInfo as any).networkTrace = networkTrace;

--- a/tests/bb/hosts.bb.spec.ts
+++ b/tests/bb/hosts.bb.spec.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import { test } from '../../src/pom/page-fixtures';
 import { createNetworkTraceCollector, NetworkTraceCapture } from '../../src/helpers/network-trace';
-import { testStep, buildKibanaUrl } from '../../src/helpers/test-utils';
+import { testStep, resolveKibanaTimeRangeRison } from '../../src/helpers/test-utils';
 import { fetchClusterData, getDocCount, getHostData } from '../../src/helpers/api-client';
 import { writeJsonReport, writeNetworkTraceReport, printResults } from '../../src/helpers/reporter';
 
@@ -22,6 +22,49 @@ function loadScenarios(): Scenario[] {
   return all.filter(s => (s.section || '').toLowerCase() === 'hosts');
 }
 
+// Replaces `dateRange` and `limit` inside the `_a=(...)` segment of a Hosts
+// URL, preserving every other field Hosts wrote. Safe assumption: inside the
+// `_a=(...)` segment both `dateRange:` and `limit:` appear exactly once, and
+// no other query param (currently only `controlPanels=`) contains either
+// token. The caller MUST only invoke this once the URL has Hosts' canonical
+// `_a=(...)` written; otherwise the regexes are no-ops.
+function upsertHostsState(url: string, hostLimit: number, from: string, to: string): string {
+  let next: string;
+  try {
+    next = decodeURIComponent(url);
+  } catch {
+    next = url;
+  }
+
+  const dateRange = `dateRange:(from:${from},to:${to})`;
+  if (/dateRange:\(from:[^,]+,to:[^)]+\)/.test(next)) {
+    next = next.replace(/dateRange:\(from:[^,]+,to:[^)]+\)/, dateRange);
+  } else if (next.includes('_a=(')) {
+    next = next.replace('_a=(', `_a=(${dateRange},`);
+  }
+
+  if (/limit:\d+/.test(next)) {
+    next = next.replace(/limit:\d+/, `limit:${hostLimit}`);
+  } else if (next.includes('_a=(')) {
+    next = next.replace('_a=(', `_a=(limit:${hostLimit},`);
+  }
+
+  return next;
+}
+
+function hasDesiredHostsState(url: string, hostLimit: number, from: string, to: string): boolean {
+  try {
+    const parsed = new URL(url, 'http://placeholder');
+    const search = decodeURIComponent(parsed.search);
+    return (
+      search.includes(`dateRange:(from:${from},to:${to})`) &&
+      search.includes(`limit:${hostLimit}`)
+    );
+  } catch {
+    return false;
+  }
+}
+
 const HOSTS_APP_PATH = '/app/metrics/hosts';
 const scenarios = loadScenarios();
 
@@ -35,12 +78,7 @@ for (const scenario of scenarios) {
     const HOST_LIMIT = scenario.host_limit;
     const ZOOM = scenario.zoom;
 
-    test.beforeAll('Check data', async ({ request, log }) => {
-      log.info('Checking if host data is available in the last 24 hours');
-      const nodesData = await getHostData(request);
-      const nodesArr = nodesData.nodes;
-      const metricValue = nodesData.nodes[0]?.metrics?.[0]?.value;
-      test.skip(nodesArr.length == 0 || metricValue == null, 'Test is skipped: No node data is available');
+    test.beforeAll('Check data', async ({ log }) => {
       log.info('Fetching cluster data');
       clusterData = await fetchClusterData();
       doc_count = await getDocCount();
@@ -65,7 +103,7 @@ for (const scenario of scenarios) {
     });
 
     const testName = `Hosts - ${scenario.name}`;
-    const stepDescription = `Opening ${HOSTS_APP_PATH} with host_limit=${HOST_LIMIT} and zoom=${ZOOM} and collecting full navigation metrics`;
+    const stepDescription = `Opening ${HOSTS_APP_PATH} with host_limit=${HOST_LIMIT} and zoom=${ZOOM} via bootstrap+rewrite; measuring only the desired-state navigation`;
 
     test(testName,
       async ({ headerBar, hostsPage, notifications, perfMetrics, page, log }, testInfo) => {
@@ -91,49 +129,166 @@ for (const scenario of scenarios) {
 
         try {
           await testStep('step01', stepData, page, async () => {
-            const appState = `(limit:${HOST_LIMIT})`;
-            const kibanaUrl = buildKibanaUrl(HOSTS_APP_PATH, appState);
-            log.info(`Navigating directly to ${HOSTS_APP_PATH} with host_limit=${HOST_LIMIT}`);
-            await perfMetrics.takeBaseline();
-            await networkTraceCollector.start();
-            traceCollectionStarted = true;
-            await page.goto(kibanaUrl);
+            const { from, to } = resolveKibanaTimeRangeRison();
+
+            log.info(`Resolved Hosts target state: dateRange:(from:${from},to:${to}), limit:${HOST_LIMIT}`);
+
+            // 0) Install zoom hook BEFORE any navigation. `addInitScript`
+            //    runs on every new document at the earliest possible moment,
+            //    so the page renders at the target zoom from the first paint
+            //    rather than re-layouting mid-test. This is important because
+            //    lower zoom reveals more visualizations; we want all charts
+            //    laid out before measurement starts.
+            log.info(`Installing zoom hook (target zoom: ${ZOOM})`);
+            await page.addInitScript((z) => {
+              const apply = () => {
+                if (document.body) {
+                  document.body.style.zoom = String(z);
+                  return true;
+                }
+                return false;
+              };
+              if (apply()) return;
+              const obs = new MutationObserver(() => {
+                if (apply()) obs.disconnect();
+              });
+              obs.observe(document.documentElement, { childList: true, subtree: false });
+            }, ZOOM);
+
+            // 1) Bootstrap navigation. Not measured. Lets Hosts hydrate to
+            //    its canonical URL shape so we can read every field it
+            //    expects in `_a` without baking field names into this code.
+            log.info(`Bootstrapping ${HOSTS_APP_PATH} (warm-up; not measured)`);
+            await page.goto(HOSTS_APP_PATH);
             const loadingIndicator = page.locator('[data-test-subj="globalLoadingIndicator"]');
             await loadingIndicator.waitFor({ state: 'visible', timeout: 2000 }).catch(() => {});
             await loadingIndicator.waitFor({ state: 'hidden', timeout: 180000 });
 
-            log.info(`Setting page zoom to ${ZOOM}`);
-            await page.evaluate((z) => { document.body.style.zoom = String(z); }, ZOOM);
+            // 2) Wait for the full-state marker. `controlPanels=` is the
+            //    last thing Hosts writes during init; when present alongside
+            //    `_a=(`, the URL has Hosts' complete canonical state and
+            //    `upsertHostsState` will produce a real rewrite (not a no-op).
+            log.info('Waiting for Hosts to write its canonical state to the URL');
+            await page.waitForFunction(
+              () => /[?&]controlPanels=/.test(location.search) && /[?&]_a=\(/.test(location.search),
+              null,
+              { timeout: 60_000 }
+            );
+            const bootstrapUrl = page.url();
+            log.info(`Hosts canonical URL captured: ${bootstrapUrl}`);
+
+            // 3) Upsert desired dateRange/limit, preserving every other field
+            //    Hosts wrote. The result still looks "complete" to Hosts, so
+            //    it accepts our values instead of replacing them with the
+            //    persisted default state.
+            const desiredUrl = upsertHostsState(bootstrapUrl, HOST_LIMIT, from, to);
+            log.info(`Desired URL with scenario state: ${desiredUrl}`);
+
+            // Small local helpers shared between the warm-up and measured
+            // navigations so both paths behave identically.
+            const navigateAndConfirmDesiredState = async () => {
+              await page.goto(desiredUrl);
+              await loadingIndicator.waitFor({ state: 'visible', timeout: 2000 }).catch(() => {});
+              await loadingIndicator.waitFor({ state: 'hidden', timeout: 180000 });
+
+              await page.waitForFunction(
+                ({ from, to, limit }) => {
+                  let search = '';
+                  try { search = decodeURIComponent(location.search); } catch { search = location.search; }
+                  return search.includes(`dateRange:(from:${from},to:${to})`)
+                    && search.includes(`limit:${limit}`);
+                },
+                { from, to, limit: HOST_LIMIT },
+                { timeout: 30_000 }
+              );
+
+              const settledUrl = page.url();
+              if (!hasDesiredHostsState(settledUrl, HOST_LIMIT, from, to)) {
+                throw new Error(`Hosts URL state drifted from desired. Final URL: ${settledUrl}`);
+              }
+              return settledUrl;
+            };
+
+            const waitForHostsFullyRendered = async () => {
+              await Promise.race([
+                Promise.all([
+                  hostsPage.assertHostsNumber(),
+                  hostsPage.assertVisibilityHostsTable(),
+                  hostsPage.assertVisibilityVisualization(cpuUsageKPI),
+                  hostsPage.assertVisibilityVisualization(normalizedLoadKPI),
+                  hostsPage.assertVisibilityVisualization(memoryUsageKPI),
+                  hostsPage.assertVisibilityVisualization(diskUsageKPI),
+                  hostsPage.assertVisibilityVisualization(cpuUsage),
+                  hostsPage.assertVisibilityVisualization(normalizedLoad),
+                  headerBar.assertLoadingIndicator(),
+                ]),
+                hostsPage.assertVisualizationNoData(cpuUsageKPI).then(() => {
+                  throw new Error('Test is failed because no visualization data available');
+                }),
+                hostsPage.assertVisualizationNoData(normalizedLoadKPI).then(() => {
+                  throw new Error('Test is failed because no visualization data available');
+                }),
+                hostsPage.assertVisualizationNoData(memoryUsageKPI).then(() => {
+                  throw new Error('Test is failed because no visualization data available');
+                }),
+                hostsPage.assertVisualizationNoData(diskUsageKPI).then(() => {
+                  throw new Error('Test is failed because no visualization data available');
+                }),
+                notifications.assertErrorFetchingResource().then(() => {
+                  throw new Error('Test is failed because Hosts data failed to load');
+                })
+              ]);
+            };
+
+            // 4) WARM-UP NAVIGATION — NOT measured.
+            //
+            // Why this exists:
+            //   The bootstrap above warms only the Hosts shell at *default*
+            //   state (limit:100, now-15m). The scenario state (e.g.
+            //   limit:500, now-30m) is strictly broader: more rows trigger
+            //   additional Lens chart chunks, wider time ranges pull more
+            //   data, and certain Kibana internal endpoints (security/me,
+            //   ml_capabilities, infra/host, ...) pay a one-time
+            //   cold-cache cost on first call after a Kibana restart.
+            //
+            //   If we measured the FIRST scenario-state navigation, those
+            //   one-time costs would land inside the measurement window
+            //   and dominate the captured numbers, masking the real
+            //   per-scenario render cost we're trying to compare. The same
+            //   problem would also make consecutive runs of the same
+            //   scenario diverge wildly depending on whether the chunks /
+            //   internal caches happened to be warm from a previous run.
+            //
+            //   By performing a throwaway navigation to the scenario URL
+            //   first and waiting for every visibility assertion to pass,
+            //   we guarantee that by the time we measure: (a) every JS
+            //   chunk the scenario state needs is parsed and in V8's code
+            //   cache, (b) every cold Kibana endpoint has been hit at
+            //   least once, and (c) the Hosts URL container is fully
+            //   hydrated. The measured navigation then reflects the
+            //   actual per-scenario cost on a fully-warm Kibana session,
+            //   which matches the experience of a returning user — the
+            //   population this benchmark is intended to model.
+            log.info('Warm-up navigation to desired URL (NOT measured)');
+            await navigateAndConfirmDesiredState();
+            await waitForHostsFullyRendered();
+            log.info('Warm-up complete; Hosts fully rendered. Starting measurement.');
+
+            // 5) MEASURED navigation. perfMetrics baseline + network trace
+            //    start HERE so the captured metrics reflect ONLY the cost
+            //    of re-rendering Hosts on a fully-warm Kibana. `page.goto`
+            //    to the same URL forces a real navigation (no bfcache /
+            //    same-document optimisation), so we are still measuring a
+            //    full page load — just one served from warm caches/state.
+            await perfMetrics.takeBaseline();
+            await networkTraceCollector.start();
+            traceCollectionStarted = true;
+
+            const finalUrl = await navigateAndConfirmDesiredState();
+            log.info(`Hosts URL stabilized with desired state: ${finalUrl}`);
 
             log.info('Asserting visibility of elements on the Hosts page');
-            await Promise.race([
-              Promise.all([
-                hostsPage.assertHostsNumber(),
-                hostsPage.assertVisibilityHostsTable(),
-                hostsPage.assertVisibilityVisualization(cpuUsageKPI),
-                hostsPage.assertVisibilityVisualization(normalizedLoadKPI),
-                hostsPage.assertVisibilityVisualization(memoryUsageKPI),
-                hostsPage.assertVisibilityVisualization(diskUsageKPI),
-                hostsPage.assertVisibilityVisualization(cpuUsage),
-                hostsPage.assertVisibilityVisualization(normalizedLoad),
-                headerBar.assertLoadingIndicator(),
-              ]),
-              hostsPage.assertVisualizationNoData(cpuUsageKPI).then(() => {
-                throw new Error('Test is failed because no visualization data available');
-              }),
-              hostsPage.assertVisualizationNoData(normalizedLoadKPI).then(() => {
-                throw new Error('Test is failed because no visualization data available');
-              }),
-              hostsPage.assertVisualizationNoData(memoryUsageKPI).then(() => {
-                throw new Error('Test is failed because no visualization data available');
-              }),
-              hostsPage.assertVisualizationNoData(diskUsageKPI).then(() => {
-                throw new Error('Test is failed because no visualization data available');
-              }),
-              notifications.assertErrorFetchingResource().then(() => {
-                throw new Error('Test is failed because Hosts data failed to load');
-              })
-            ]);
+            await waitForHostsFullyRendered();
 
             log.info('Step 1 settled, collecting full performance metrics');
             const collectedPerfMetrics = await perfMetrics.collect();
@@ -145,6 +300,8 @@ for (const scenario of scenarios) {
               networkTraceId: networkTrace.traceId,
               networkSummary: networkTrace.summary,
               slowestRequests: networkTrace.slowestRequests,
+              slowestApiRequests: networkTrace.slowestApiRequests,
+              slowestStaticRequests: networkTrace.slowestStaticRequests,
             };
             (testInfo as any).perfData = perfData;
             (testInfo as any).networkTrace = networkTrace;


### PR DESCRIPTION
Resolves https://github.com/elastic/oblt-playwright/issues/458

## Summary

This PR improves reliability and interpretability of the BB scenario runners, with the main focus on the Hosts benchmark.

### What changed

- Reworked `tests/bb/hosts.bb.spec.ts` to handle Kibana Hosts URL rewrite behavior safely:
  - bootstrap Hosts once,
  - capture canonical URL state,
  - upsert scenario-specific `dateRange` + `limit` in `_a`,
  - warm up once to desired state (not measured),
  - measure a second navigation to the same desired URL.
- Added explicit validation that final URL state matches the intended scenario before collecting metrics.
- Moved Hosts time-range resolution to shared helper usage (`resolveKibanaTimeRangeRison`) and clarified `buildKibanaUrl` scope for hash-routed apps.
- Enhanced network trace model and reports:
  - request categorization (`api` / `static` / `other`),
  - `fromDiskCache` surfaced in slow-request output,
  - stratified slowest lists: `slowestApiRequests` and `slowestStaticRequests`.
- Updated report rendering to print separate tables for API vs static slow requests and strip URL origin for readability.
- Extended index mappings for new slow-request fields and arrays.
- Updated `discover.bb.spec.ts` to include new stratified slow-request fields in `perfData`.
- Added documentation: `docs/bb-scenario-runners/hosts-benchmark-overview.md`.

## Why

Hosts can rewrite URL state during boot and first-time warm-up effects can dominate measured timings.  
Without guarding against this, benchmark runs are noisy and scenario-to-scenario comparisons are less trustworthy.

This change makes the measured window explicit and consistent, so metrics reflect scenario render cost rather than one-time initialization effects.
