### PR TITLE
Exclude full request list from trace file

### DIFF
--- a/src/helpers/reporter.ts
+++ b/src/helpers/reporter.ts
@@ -55,6 +55,12 @@ function stripUrlOrigin(url: string | undefined): string {
   }
 }
 
+// Cap on rows rendered into the console-friendly slowest-requests table.
+// The JSON report keeps a wider list (see `slowRequestCount` at the collector
+// call site) for offline drill-down; the console view stays compact so it
+// doesn't drown out the rest of the per-test summary.
+const PRINTED_SLOWEST_REQUESTS = 5;
+
 // Renders a slowest-requests table with Type and Cache columns. The Cache
 // column shows `disk` for `fromDiskCache: true` so a reader can immediately
 // see whether a fast/slow result is explained by cache state rather than
@@ -75,7 +81,7 @@ function printSlowestRequestsTable(title: string, requests: any[] | undefined) {
     ],
   });
   table.addRows(
-    requests.map((request: any) => ({
+    requests.slice(0, PRINTED_SLOWEST_REQUESTS).map((request: any) => ({
       method: request.method,
       status: request.status ?? 'N/A',
       type: request.resourceType ?? 'N/A',
@@ -156,7 +162,6 @@ export async function writeNetworkTraceReport(
     captureStartedAt: networkTrace.captureStartedAt,
     captureEndedAt: networkTrace.captureEndedAt,
     maxNetworkRequests: networkTrace.maxNetworkRequests,
-    requests: networkTrace.requests,
   };
 
   log.info(`Saving network trace file to ${outputPath}`);

--- a/src/index-templates.ts
+++ b/src/index-templates.ts
@@ -71,7 +71,7 @@ const performanceMetricsProperties = {
 export const oblt_playwright = {
       mappings: {
         properties: {
-          title: { type: 'text' },
+          title: { type: 'text', fields: { keyword: { type: 'keyword', ignore_above: 256 } } },
           startTime: { type: 'date' },
           doc_count: {
             properties: {
@@ -152,7 +152,7 @@ export const oblt_playwright = {
 export const oblt_playwright_network_traces = {
       mappings: {
         properties: {
-          title: { type: 'text' },
+          title: { type: 'text', fields: { keyword: { type: 'keyword', ignore_above: 256 } } },
           startTime: { type: 'date' },
           period: { type: 'keyword' },
           status: { type: 'keyword' },

--- a/tests/bb/hosts.bb.spec.ts
+++ b/tests/bb/hosts.bb.spec.ts
@@ -124,7 +124,7 @@ for (const scenario of scenarios) {
 
         const networkTraceCollector = await createNetworkTraceCollector(page, log, {
           maxNetworkRequests: 2000,
-          slowRequestCount: 5,
+          slowRequestCount: 20,
         });
 
         try {


### PR DESCRIPTION
### Summary of changes

- `src/helpers/reporter.ts`
  - `writeNetworkTraceReport` no longer writes requests: `networkTrace.requests` to the trace JSON, so the file stays small.
  - Added a `PRINTED_SLOWEST_REQUESTS = 5` cap, and `printSlowestRequestsTable` now slices its input to that cap. This means however many slowest entries land in the JSON, the console table prints only the top 5.
- `tests/bb/hosts.bb.spec.ts`
  - Bumped `slowRequestCount` from 5 to 20 at the `createNetworkTraceCollector` call sites. The JSON report's `slowestRequests` / `slowestApiRequests` / `slowestStaticRequests` arrays now hold up to 20 entries each, while the console output stays at 5 via the cap above.
- Both `oblt_playwright` and `oblt_playwright_network_traces` index templates now have title as a multi‑field: `text` for full‑text search, `title.keyword` (with ignore_above: 256) for terms aggregations, sorting, and exact filtering. 