### PR TITLE
Hosts BB runner: measure cold and warm load times separately

### DIFF
--- a/docs/bb-scenario-runners/hosts-benchmark-overview.md
+++ b/docs/bb-scenario-runners/hosts-benchmark-overview.md
@@ -4,7 +4,7 @@
 
 This test measures how fast the Kibana **Hosts** page renders and becomes usable for a defined scenario (time range, host limit, and zoom).
 
-It is designed to produce **stable, comparable** results across runs and scenarios.
+It captures **both cold-cache and warmed steady-state** performance so the two can be compared directly.
 
 ## What the test validates
 
@@ -19,48 +19,47 @@ For each Hosts scenario, the test confirms that:
 
 ## How measurement is conducted
 
-The test intentionally separates **setup/warm-up** from the **measured window**.
+The test runs a one-time URL-state setup, then performs **three measured navigations** back-to-back.
 
-### 1) Setup and state stabilization (not measured)
+### 1) URL-state setup (not measured)
 
-Before timing starts, the test:
+Before any measurement:
 
-- Opens Hosts once to let Kibana generate its canonical URL state.
-- Rewrites URL state to the desired scenario values (`dateRange`, `limit`).
-- Performs one full warm-up navigation to that desired URL.
-- Waits until all required visualizations are fully rendered.
+- A zoom hook is installed via `addInitScript` so every navigation renders at the scenario zoom from the first paint.
+- The Hosts page is opened once at its default state so Kibana writes its canonical URL shape (`_a=(...)` plus `controlPanels=`).
+- The captured URL is rewritten to the scenario values (`dateRange`, `limit`) while preserving every other field Hosts wrote.
 
-This stage exists because Kibana may rewrite URL state during boot and may load one-time assets/endpoints on first access. Including that in measurements would add noise and reduce comparability.
+This stage is required infrastructure (it discovers the canonical URL shape); it is **not** a performance warm-up.
 
-### 2) Measured navigation
+### 2) Three measured iterations
 
-Only after warm-up is complete, the test starts measurement:
+The same desired URL is loaded three times in a row. Each iteration:
 
-- Takes performance baseline snapshot.
-- Starts network trace capture.
-- Navigates again to the **same desired URL**.
-- Waits for:
-  - loading completion,
-  - correct URL state,
-  - full visualization readiness.
+- Takes a fresh performance baseline.
+- Starts a new network trace.
+- Navigates to the desired URL via `page.goto` (a full page load — no bfcache).
+- Waits for loading completion, correct URL state, and full visualization readiness.
+- Collects performance and network data, and emits its own JSON + network-trace report file.
 
-Then it collects performance and network data.
+The three iterations are labeled:
 
-## What is measured
+| Iteration | Label   | What it captures |
+| --------- | ------- | ---------------- |
+| 1         | `cold`  | First scenario-state load: includes one-time costs (Lens chart chunks parsed by V8, cold Kibana endpoints, disk-cacheable static assets fetched from network). |
+| 2         | `warm1` | Steady-state load on a fully-warmed Kibana session. |
+| 3         | `warm2` | Second steady-state sample; lets you sanity-check variance between consecutive warm runs. |
 
-The report includes:
+## What is reported
 
-- Browser timing metrics (for example LCP, FCP, TTFB, DOM Content Loaded, Page Load).
-- Runtime work metrics (script, layout, style recalculation, task duration, JS heap).
-- Network summary (finished/failed requests).
-- Slowest requests, split into:
-  - API requests
-  - static assets
+Each iteration produces:
 
-This split helps separate backend/data latency from static asset/cache effects.
+- A JSON report (`..._cold.json`, `..._warm1.json`, `..._warm2.json`) containing browser timing, runtime work metrics, and the network summary for that iteration.
+- A network-trace file (`..._cold.network-trace.json`, etc.) with the full per-request trace.
+
+The console output prints one performance table per iteration so cold and warm numbers can be compared side-by-side without opening the JSON files. Slowest requests are split into API and static-asset tables.
 
 ## Why this approach is used
 
-This benchmark targets **returning-user performance** (realistic day-to-day usage), not first-ever cold start.
-
-By warming up first and measuring the second navigation, the test minimizes one-time startup effects and focuses on scenario-specific render cost. This makes trend tracking and scenario comparison reliable for decision-making.
+- The **cold** iteration models a user landing on the scenario for the first time after a Kibana restart or a fresh browser session.
+- The **warm** iterations model the returning-user experience and provide the stable cross-run signal.
+- Running both in the same test, on the same page session, keeps the cold-vs-warm comparison fair: identical scenario, identical URL, identical assertions — only the cache state differs.

--- a/src/helpers/reporter.ts
+++ b/src/helpers/reporter.ts
@@ -26,6 +26,16 @@ function buildReportFileBase(testStartTime: string, testTitle: string): string {
   return `${new Date(testStartTime).toISOString().replace(/:/g, '_')}_${testTitle.replace(/\s/g, "_").toLowerCase()}`;
 }
 
+// Per-iteration report support. `fileNameSuffix` distinguishes files on disk
+// when a single test produces several reports (e.g. `_cold`, `_warm1`,
+// `_warm2`). `titleSuffix` distinguishes those same reports in the rendered
+// console output. Both are additive and default to '' so existing callers
+// keep current behaviour.
+export type ReportOptions = {
+  fileNameSuffix?: string;
+  titleSuffix?: string;
+};
+
 function buildPeriodLabel() {
   return ABSOLUTE_TIME_RANGE
     ? `From ${START_DATE} to ${END_DATE}`
@@ -103,12 +113,16 @@ export async function writeJsonReport(
   stepData?: object[],
   cacheStats?: object,
   perfMetrics?: object,
+  options?: ReportOptions,
 ) {
   let build_flavor: any = clusterData.version.build_flavor;
   let cluster_name: any = clusterData.cluster_name;
   let files: string[] = [];
 
-  const fileName = `${buildReportFileBase(testStartTime, testInfo.title)}.json`;
+  const fileSuffix = options?.fileNameSuffix ?? '';
+  const titleSuffix = options?.titleSuffix ?? '';
+
+  const fileName = `${buildReportFileBase(testStartTime, testInfo.title)}${fileSuffix}.json`;
   files.push(fileName);
 
   ensureOutputDirectory();
@@ -116,7 +130,7 @@ export async function writeJsonReport(
   const outputPath = path.join(outputDirectory, fileName);
 
   const reportData = {
-    title: testInfo.title,
+    title: `${testInfo.title}${titleSuffix}`,
     startTime: testStartTime,
     doc_count: docsCount,
     period: buildPeriodLabel(),
@@ -140,14 +154,18 @@ export async function writeNetworkTraceReport(
   testStartTime: string,
   networkTrace: NetworkTraceCapture,
   perfMetrics?: object,
+  options?: ReportOptions,
 ) {
   ensureOutputDirectory();
 
-  const fileName = `${buildReportFileBase(testStartTime, testInfo.title)}.network-trace.json`;
+  const fileSuffix = options?.fileNameSuffix ?? '';
+  const titleSuffix = options?.titleSuffix ?? '';
+
+  const fileName = `${buildReportFileBase(testStartTime, testInfo.title)}${fileSuffix}.network-trace.json`;
   const outputPath = path.join(outputDirectory, fileName);
 
   const traceReportData = {
-    title: testInfo.title,
+    title: `${testInfo.title}${titleSuffix}`,
     startTime: testStartTime,
     period: buildPeriodLabel(),
     status: testInfo.status,

--- a/tests/bb/hosts.bb.spec.ts
+++ b/tests/bb/hosts.bb.spec.ts
@@ -68,6 +68,26 @@ function hasDesiredHostsState(url: string, hostLimit: number, from: string, to: 
 const HOSTS_APP_PATH = '/app/metrics/hosts';
 const scenarios = loadScenarios();
 
+// Each scenario runs the measured navigation three times to expose both
+// cold-cache cost (first hit) and warmed steady-state cost (subsequent hits).
+// The bootstrap navigation is shared across all three and is NOT counted as
+// an iteration; it only exists to read Hosts' canonical URL shape.
+type IterationDescriptor = {
+  label: 'cold' | 'warm1' | 'warm2';
+  step: 'step01' | 'step02' | 'step03';
+};
+const ITERATIONS: IterationDescriptor[] = [
+  { label: 'cold', step: 'step01' },
+  { label: 'warm1', step: 'step02' },
+  { label: 'warm2', step: 'step03' },
+];
+
+type IterationResult = {
+  label: IterationDescriptor['label'];
+  perfData: object;
+  networkTrace: NetworkTraceCapture;
+};
+
 for (const scenario of scenarios) {
   test.describe(`Hosts - ${scenario.name}`, () => {
     let clusterData: any;
@@ -85,17 +105,39 @@ for (const scenario of scenarios) {
     });
 
     test.afterEach('Log test results', async ({ log }, testInfo) => {
-      const perfData = (testInfo as any).perfData;
-      const networkTrace = (testInfo as any).networkTrace as NetworkTraceCapture | null | undefined;
       const stepData = (testInfo as any).stepData;
-      const reportFiles = await writeJsonReport(
-        log, clusterData, testInfo, testStartTime, doc_count,
-        stepData, undefined, perfData
-      );
-      if (networkTrace) {
-        await writeNetworkTraceReport(log, clusterData, testInfo, testStartTime, networkTrace, perfData ?? undefined);
+      const iterations = (testInfo as any).iterations as IterationResult[] | undefined;
+
+      if (Array.isArray(iterations) && iterations.length > 0) {
+        // Per-iteration reports: one JSON + one network-trace file per
+        // iteration, suffixed and title-tagged so cold/warm1/warm2 are
+        // distinguishable both on disk and in the printed console output.
+        for (const iteration of iterations) {
+          const fileNameSuffix = `_${iteration.label}`;
+          const titleSuffix = ` [${iteration.label}]`;
+          const reportFiles = await writeJsonReport(
+            log, clusterData, testInfo, testStartTime, doc_count,
+            stepData, undefined, iteration.perfData,
+            { fileNameSuffix, titleSuffix },
+          );
+          if (iteration.networkTrace) {
+            await writeNetworkTraceReport(
+              log, clusterData, testInfo, testStartTime, iteration.networkTrace,
+              iteration.perfData,
+              { fileNameSuffix, titleSuffix },
+            );
+          }
+          reports.push(...reportFiles.filter(item => typeof item === 'string'));
+        }
+      } else {
+        // Fallback path for partial runs (e.g. test failed before any
+        // iteration completed): still emit a report with whatever stepData
+        // was captured so the failure is recorded.
+        const reportFiles = await writeJsonReport(
+          log, clusterData, testInfo, testStartTime, doc_count, stepData,
+        );
+        reports.push(...reportFiles.filter(item => typeof item === 'string'));
       }
-      reports.push(...reportFiles.filter(item => typeof item === 'string'));
     });
 
     test.afterAll('Print test results', async ({}) => {
@@ -103,7 +145,7 @@ for (const scenario of scenarios) {
     });
 
     const testName = `Hosts - ${scenario.name}`;
-    const stepDescription = `Opening ${HOSTS_APP_PATH} with host_limit=${HOST_LIMIT} and zoom=${ZOOM} via bootstrap+rewrite; measuring only the desired-state navigation`;
+    const stepDescription = `Opening ${HOSTS_APP_PATH} with host_limit=${HOST_LIMIT} and zoom=${ZOOM}: bootstrap + 3 measured iterations (cold, warm1, warm2)`;
 
     test(testName,
       async ({ headerBar, hostsPage, notifications, perfMetrics, page, log }, testInfo) => {
@@ -115,12 +157,10 @@ for (const scenario of scenarios) {
         const normalizedLoad = "hostsView-metricChart-normalizedLoad1m";
 
         let stepData: object[] = [];
-        let perfData: object | null = null;
-        let networkTrace: NetworkTraceCapture | null = null;
+        const iterations: IterationResult[] = [];
         let traceCollectionStarted = false;
         (testInfo as any).stepData = stepData;
-        (testInfo as any).perfData = perfData;
-        (testInfo as any).networkTrace = networkTrace;
+        (testInfo as any).iterations = iterations;
 
         const networkTraceCollector = await createNetworkTraceCollector(page, log, {
           maxNetworkRequests: 2000,
@@ -128,189 +168,172 @@ for (const scenario of scenarios) {
         });
 
         try {
-          await testStep('step01', stepData, page, async () => {
-            const { from, to } = resolveKibanaTimeRangeRison();
+          const { from, to } = resolveKibanaTimeRangeRison();
+          log.info(`Resolved Hosts target state: dateRange:(from:${from},to:${to}), limit:${HOST_LIMIT}`);
 
-            log.info(`Resolved Hosts target state: dateRange:(from:${from},to:${to}), limit:${HOST_LIMIT}`);
+          // 0) Install zoom hook BEFORE any navigation. `addInitScript`
+          //    runs on every new document at the earliest possible moment,
+          //    so the page renders at the target zoom from the first paint
+          //    rather than re-layouting mid-test. This is important because
+          //    lower zoom reveals more visualizations; we want all charts
+          //    laid out before measurement starts.
+          log.info(`Installing zoom hook (target zoom: ${ZOOM})`);
+          await page.addInitScript((z) => {
+            const apply = () => {
+              if (document.body) {
+                document.body.style.zoom = String(z);
+                return true;
+              }
+              return false;
+            };
+            if (apply()) return;
+            const obs = new MutationObserver(() => {
+              if (apply()) obs.disconnect();
+            });
+            obs.observe(document.documentElement, { childList: true, subtree: false });
+          }, ZOOM);
 
-            // 0) Install zoom hook BEFORE any navigation. `addInitScript`
-            //    runs on every new document at the earliest possible moment,
-            //    so the page renders at the target zoom from the first paint
-            //    rather than re-layouting mid-test. This is important because
-            //    lower zoom reveals more visualizations; we want all charts
-            //    laid out before measurement starts.
-            log.info(`Installing zoom hook (target zoom: ${ZOOM})`);
-            await page.addInitScript((z) => {
-              const apply = () => {
-                if (document.body) {
-                  document.body.style.zoom = String(z);
-                  return true;
-                }
-                return false;
-              };
-              if (apply()) return;
-              const obs = new MutationObserver(() => {
-                if (apply()) obs.disconnect();
-              });
-              obs.observe(document.documentElement, { childList: true, subtree: false });
-            }, ZOOM);
+          // 1) Bootstrap navigation. Not an iteration, not measured. Its
+          //    only purpose is to let Hosts hydrate to its canonical URL
+          //    shape so we can read every field it expects in `_a` without
+          //    baking field names into this code. The first scenario-state
+          //    navigation that follows is treated as the COLD measurement.
+          log.info(`Bootstrapping ${HOSTS_APP_PATH} (URL-state setup; not measured)`);
+          await page.goto(HOSTS_APP_PATH);
+          const loadingIndicator = page.locator('[data-test-subj="globalLoadingIndicator"]');
+          await loadingIndicator.waitFor({ state: 'visible', timeout: 2000 }).catch(() => {});
+          await loadingIndicator.waitFor({ state: 'hidden', timeout: 180000 });
 
-            // 1) Bootstrap navigation. Not measured. Lets Hosts hydrate to
-            //    its canonical URL shape so we can read every field it
-            //    expects in `_a` without baking field names into this code.
-            log.info(`Bootstrapping ${HOSTS_APP_PATH} (warm-up; not measured)`);
-            await page.goto(HOSTS_APP_PATH);
-            const loadingIndicator = page.locator('[data-test-subj="globalLoadingIndicator"]');
+          // 2) Wait for the full-state marker. `controlPanels=` is the
+          //    last thing Hosts writes during init; when present alongside
+          //    `_a=(`, the URL has Hosts' complete canonical state and
+          //    `upsertHostsState` will produce a real rewrite (not a no-op).
+          log.info('Waiting for Hosts to write its canonical state to the URL');
+          await page.waitForFunction(
+            () => /[?&]controlPanels=/.test(location.search) && /[?&]_a=\(/.test(location.search),
+            null,
+            { timeout: 60_000 }
+          );
+          const bootstrapUrl = page.url();
+          log.info(`Hosts canonical URL captured: ${bootstrapUrl}`);
+
+          // 3) Upsert desired dateRange/limit, preserving every other field
+          //    Hosts wrote. The result still looks "complete" to Hosts, so
+          //    it accepts our values instead of replacing them with the
+          //    persisted default state.
+          const desiredUrl = upsertHostsState(bootstrapUrl, HOST_LIMIT, from, to);
+          log.info(`Desired URL with scenario state: ${desiredUrl}`);
+
+          // Helpers shared by every measured iteration so each navigation
+          // resolves the same way and any drift in URL state is caught
+          // before metrics are collected.
+          const navigateAndConfirmDesiredState = async () => {
+            await page.goto(desiredUrl);
             await loadingIndicator.waitFor({ state: 'visible', timeout: 2000 }).catch(() => {});
             await loadingIndicator.waitFor({ state: 'hidden', timeout: 180000 });
 
-            // 2) Wait for the full-state marker. `controlPanels=` is the
-            //    last thing Hosts writes during init; when present alongside
-            //    `_a=(`, the URL has Hosts' complete canonical state and
-            //    `upsertHostsState` will produce a real rewrite (not a no-op).
-            log.info('Waiting for Hosts to write its canonical state to the URL');
             await page.waitForFunction(
-              () => /[?&]controlPanels=/.test(location.search) && /[?&]_a=\(/.test(location.search),
-              null,
-              { timeout: 60_000 }
+              ({ from, to, limit }) => {
+                let search = '';
+                try { search = decodeURIComponent(location.search); } catch { search = location.search; }
+                return search.includes(`dateRange:(from:${from},to:${to})`)
+                  && search.includes(`limit:${limit}`);
+              },
+              { from, to, limit: HOST_LIMIT },
+              { timeout: 30_000 }
             );
-            const bootstrapUrl = page.url();
-            log.info(`Hosts canonical URL captured: ${bootstrapUrl}`);
 
-            // 3) Upsert desired dateRange/limit, preserving every other field
-            //    Hosts wrote. The result still looks "complete" to Hosts, so
-            //    it accepts our values instead of replacing them with the
-            //    persisted default state.
-            const desiredUrl = upsertHostsState(bootstrapUrl, HOST_LIMIT, from, to);
-            log.info(`Desired URL with scenario state: ${desiredUrl}`);
+            const settledUrl = page.url();
+            if (!hasDesiredHostsState(settledUrl, HOST_LIMIT, from, to)) {
+              throw new Error(`Hosts URL state drifted from desired. Final URL: ${settledUrl}`);
+            }
+            return settledUrl;
+          };
 
-            // Small local helpers shared between the warm-up and measured
-            // navigations so both paths behave identically.
-            const navigateAndConfirmDesiredState = async () => {
-              await page.goto(desiredUrl);
-              await loadingIndicator.waitFor({ state: 'visible', timeout: 2000 }).catch(() => {});
-              await loadingIndicator.waitFor({ state: 'hidden', timeout: 180000 });
+          const waitForHostsFullyRendered = async () => {
+            await Promise.race([
+              Promise.all([
+                hostsPage.assertHostsNumber(),
+                hostsPage.assertVisibilityHostsTable(),
+                hostsPage.assertVisibilityVisualization(cpuUsageKPI),
+                hostsPage.assertVisibilityVisualization(normalizedLoadKPI),
+                hostsPage.assertVisibilityVisualization(memoryUsageKPI),
+                hostsPage.assertVisibilityVisualization(diskUsageKPI),
+                hostsPage.assertVisibilityVisualization(cpuUsage),
+                hostsPage.assertVisibilityVisualization(normalizedLoad),
+                headerBar.assertLoadingIndicator(),
+              ]),
+              hostsPage.assertVisualizationNoData(cpuUsageKPI).then(() => {
+                throw new Error('Test is failed because no visualization data available');
+              }),
+              hostsPage.assertVisualizationNoData(normalizedLoadKPI).then(() => {
+                throw new Error('Test is failed because no visualization data available');
+              }),
+              hostsPage.assertVisualizationNoData(memoryUsageKPI).then(() => {
+                throw new Error('Test is failed because no visualization data available');
+              }),
+              hostsPage.assertVisualizationNoData(diskUsageKPI).then(() => {
+                throw new Error('Test is failed because no visualization data available');
+              }),
+              notifications.assertErrorFetchingResource().then(() => {
+                throw new Error('Test is failed because Hosts data failed to load');
+              })
+            ]);
+          };
 
-              await page.waitForFunction(
-                ({ from, to, limit }) => {
-                  let search = '';
-                  try { search = decodeURIComponent(location.search); } catch { search = location.search; }
-                  return search.includes(`dateRange:(from:${from},to:${to})`)
-                    && search.includes(`limit:${limit}`);
-                },
-                { from, to, limit: HOST_LIMIT },
-                { timeout: 30_000 }
-              );
+          // 4) MEASURED iterations.
+          //
+          // The first iteration (`cold`) is the very first time the page
+          // is loaded with the scenario state, so it includes the one-time
+          // cold-cache cost: extra Lens chart chunks parsed by V8, cold
+          // Kibana endpoints (security/me, ml_capabilities, infra/host,
+          // ...) hit for the first time at this scenario, and any disk-
+          // cacheable static assets fetched from network.
+          //
+          // The two warm iterations (`warm1`, `warm2`) navigate to the
+          // exact same URL with the same `page.goto`, so each is a full
+          // page load (no bfcache / same-document optimisation), but
+          // served from a fully-warmed Kibana session. Comparing cold
+          // vs warm reveals how much of the observed cost is one-time
+          // bootstrap versus per-render work.
+          for (const iteration of ITERATIONS) {
+            await testStep(iteration.step, stepData, page, async () => {
+              log.info(`Iteration "${iteration.label}": taking perf baseline and starting network trace`);
+              await perfMetrics.takeBaseline();
+              await networkTraceCollector.start();
+              traceCollectionStarted = true;
 
-              const settledUrl = page.url();
-              if (!hasDesiredHostsState(settledUrl, HOST_LIMIT, from, to)) {
-                throw new Error(`Hosts URL state drifted from desired. Final URL: ${settledUrl}`);
-              }
-              return settledUrl;
-            };
+              log.info(`Iteration "${iteration.label}": navigating to desired URL`);
+              const finalUrl = await navigateAndConfirmDesiredState();
+              log.info(`Iteration "${iteration.label}": URL stabilized: ${finalUrl}`);
 
-            const waitForHostsFullyRendered = async () => {
-              await Promise.race([
-                Promise.all([
-                  hostsPage.assertHostsNumber(),
-                  hostsPage.assertVisibilityHostsTable(),
-                  hostsPage.assertVisibilityVisualization(cpuUsageKPI),
-                  hostsPage.assertVisibilityVisualization(normalizedLoadKPI),
-                  hostsPage.assertVisibilityVisualization(memoryUsageKPI),
-                  hostsPage.assertVisibilityVisualization(diskUsageKPI),
-                  hostsPage.assertVisibilityVisualization(cpuUsage),
-                  hostsPage.assertVisibilityVisualization(normalizedLoad),
-                  headerBar.assertLoadingIndicator(),
-                ]),
-                hostsPage.assertVisualizationNoData(cpuUsageKPI).then(() => {
-                  throw new Error('Test is failed because no visualization data available');
-                }),
-                hostsPage.assertVisualizationNoData(normalizedLoadKPI).then(() => {
-                  throw new Error('Test is failed because no visualization data available');
-                }),
-                hostsPage.assertVisualizationNoData(memoryUsageKPI).then(() => {
-                  throw new Error('Test is failed because no visualization data available');
-                }),
-                hostsPage.assertVisualizationNoData(diskUsageKPI).then(() => {
-                  throw new Error('Test is failed because no visualization data available');
-                }),
-                notifications.assertErrorFetchingResource().then(() => {
-                  throw new Error('Test is failed because Hosts data failed to load');
-                })
-              ]);
-            };
+              log.info(`Iteration "${iteration.label}": asserting visibility of elements on the Hosts page`);
+              await waitForHostsFullyRendered();
 
-            // 4) WARM-UP NAVIGATION — NOT measured.
-            //
-            // Why this exists:
-            //   The bootstrap above warms only the Hosts shell at *default*
-            //   state (limit:100, now-15m). The scenario state (e.g.
-            //   limit:500, now-30m) is strictly broader: more rows trigger
-            //   additional Lens chart chunks, wider time ranges pull more
-            //   data, and certain Kibana internal endpoints (security/me,
-            //   ml_capabilities, infra/host, ...) pay a one-time
-            //   cold-cache cost on first call after a Kibana restart.
-            //
-            //   If we measured the FIRST scenario-state navigation, those
-            //   one-time costs would land inside the measurement window
-            //   and dominate the captured numbers, masking the real
-            //   per-scenario render cost we're trying to compare. The same
-            //   problem would also make consecutive runs of the same
-            //   scenario diverge wildly depending on whether the chunks /
-            //   internal caches happened to be warm from a previous run.
-            //
-            //   By performing a throwaway navigation to the scenario URL
-            //   first and waiting for every visibility assertion to pass,
-            //   we guarantee that by the time we measure: (a) every JS
-            //   chunk the scenario state needs is parsed and in V8's code
-            //   cache, (b) every cold Kibana endpoint has been hit at
-            //   least once, and (c) the Hosts URL container is fully
-            //   hydrated. The measured navigation then reflects the
-            //   actual per-scenario cost on a fully-warm Kibana session,
-            //   which matches the experience of a returning user — the
-            //   population this benchmark is intended to model.
-            log.info('Warm-up navigation to desired URL (NOT measured)');
-            await navigateAndConfirmDesiredState();
-            await waitForHostsFullyRendered();
-            log.info('Warm-up complete; Hosts fully rendered. Starting measurement.');
+              log.info(`Iteration "${iteration.label}": settled, collecting full performance metrics`);
+              const collectedPerfMetrics = await perfMetrics.collect();
+              const networkTrace = await networkTraceCollector.collect();
+              traceCollectionStarted = false;
 
-            // 5) MEASURED navigation. perfMetrics baseline + network trace
-            //    start HERE so the captured metrics reflect ONLY the cost
-            //    of re-rendering Hosts on a fully-warm Kibana. `page.goto`
-            //    to the same URL forces a real navigation (no bfcache /
-            //    same-document optimisation), so we are still measuring a
-            //    full page load — just one served from warm caches/state.
-            await perfMetrics.takeBaseline();
-            await networkTraceCollector.start();
-            traceCollectionStarted = true;
-
-            const finalUrl = await navigateAndConfirmDesiredState();
-            log.info(`Hosts URL stabilized with desired state: ${finalUrl}`);
-
-            log.info('Asserting visibility of elements on the Hosts page');
-            await waitForHostsFullyRendered();
-
-            log.info('Step 1 settled, collecting full performance metrics');
-            const collectedPerfMetrics = await perfMetrics.collect();
-            networkTrace = await networkTraceCollector.collect();
-            traceCollectionStarted = false;
-
-            perfData = {
-              ...collectedPerfMetrics,
-              networkTraceId: networkTrace.traceId,
-              networkSummary: networkTrace.summary,
-              slowestRequests: networkTrace.slowestRequests,
-              slowestApiRequests: networkTrace.slowestApiRequests,
-              slowestStaticRequests: networkTrace.slowestStaticRequests,
-            };
-            (testInfo as any).perfData = perfData;
-            (testInfo as any).networkTrace = networkTrace;
-          }, stepDescription);
+              const perfData = {
+                iteration: iteration.label,
+                ...collectedPerfMetrics,
+                networkTraceId: networkTrace.traceId,
+                networkSummary: networkTrace.summary,
+                slowestRequests: networkTrace.slowestRequests,
+                slowestApiRequests: networkTrace.slowestApiRequests,
+                slowestStaticRequests: networkTrace.slowestStaticRequests,
+              };
+              iterations.push({ label: iteration.label, perfData, networkTrace });
+            }, `Hosts ${iteration.label} measurement: navigate to desired URL and collect perf + network trace`);
+          }
         } finally {
-          if (traceCollectionStarted && !networkTrace) {
+          if (traceCollectionStarted) {
             try {
-              networkTrace = await networkTraceCollector.collect();
-              (testInfo as any).networkTrace = networkTrace;
+              // Best-effort drain: an iteration started a capture but
+              // crashed before collect(). Discard the partial result so
+              // the CDP session is left in a clean state for dispose().
+              await networkTraceCollector.collect();
             } catch (error: any) {
               log.warn(`Network trace collection could not be completed: ${error.message}`);
             }


### PR DESCRIPTION
## Summary

The Hosts BB runner previously discarded its most useful data point: it warmed Kibana with a throwaway navigation, then measured only the second pass. This PR drops the dedicated warm-up and runs the measured navigation **three times** per scenario, labelled `cold`, `warm1`, `warm2`. 

## What changed

### `tests/bb/hosts.bb.spec.ts`
- The bootstrap navigation (default state) **stays** — it's required infrastructure to discover Hosts' canonical URL shape so `dateRange` and `limit` can be rewritten without baking field names into this code. It is explicitly not a perf warm-up.
- The dedicated warm-up navigation is **removed**.
- The measured navigation now runs three times back-to-back inside the same Playwright test (same browser context, so cache state actually carries between iterations). Each iteration:
  - takes its own perf baseline,
  - starts a fresh network-trace capture (the existing `start()` resets collector state, so a single collector instance is reused),
  - calls `page.goto(desiredUrl)` (full load, no bfcache),
  - waits for the same assertion set as before (KPI cards, metric charts, hosts table, no error toast),
  - pushes its perf + network result into an `iterations` array on `testInfo`.

### `src/helpers/reporter.ts`
- `writeJsonReport` and `writeNetworkTraceReport` gain an optional `options: { fileNameSuffix, titleSuffix }` argument via a new `ReportOptions` type.
- The suffix lands in both the on-disk filename (`..._cold.json`, `..._warm1.json`, `..._warm2.json` plus matching `.network-trace.json` files) and the printed console title (`Hosts - <scenario> [cold]`, etc.).
- The change is additive: every existing caller (Discover BB, all Kibana specs) passes no options and produces the same output as before. `printResults` was not touched — it already iterates over each JSON file and renders one table per file, so three iteration files naturally produce three tables.

### `docs/bb-scenario-runners/hosts-benchmark-overview.md`
Rewritten to describe the new flow: URL-state setup (not measured) followed by three measured iterations, with a reference table explaining what each label captures.
